### PR TITLE
WIP: Fix race in DBDDL plugin with vtcombo

### DIFF
--- a/go/cmd/vtcombo/plugin_dbddl.go
+++ b/go/cmd/vtcombo/plugin_dbddl.go
@@ -31,7 +31,7 @@ var globalDropDb func(ctx context.Context, ksName string) error
 
 // DBDDL doesn't need to store any state - we use the global variables above instead
 type DBDDL struct {
-	createDbLock *sync.Mutex
+	mu sync.Mutex
 }
 
 // CreateDatabase implements the engine.DBDDLPlugin interface
@@ -42,8 +42,8 @@ func (plugin *DBDDL) CreateDatabase(ctx context.Context, name string) error {
 			Name: "0",
 		}},
 	}
-	plugin.createDbLock.Lock()
-	defer plugin.createDbLock.Unlock()
+	plugin.mu.Lock()
+	defer plugin.mu.Unlock()
 	return globalCreateDb(ctx, ks)
 }
 
@@ -54,6 +54,6 @@ func (plugin *DBDDL) DropDatabase(ctx context.Context, name string) error {
 
 func init() {
 	servenv.OnRun(func() {
-		engine.DBDDLRegister("vttest", &DBDDL{createDbLock: &sync.Mutex{}})
+		engine.DBDDLRegister("vttest", &DBDDL{})
 	})
 }

--- a/go/cmd/vtcombo/plugin_dbddl.go
+++ b/go/cmd/vtcombo/plugin_dbddl.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"sync"
 
 	"vitess.io/vitess/go/vt/servenv"
 	"vitess.io/vitess/go/vt/vtgate/engine"
@@ -29,7 +30,9 @@ var globalCreateDb func(ctx context.Context, ks *vttestpb.Keyspace) error
 var globalDropDb func(ctx context.Context, ksName string) error
 
 // DBDDL doesn't need to store any state - we use the global variables above instead
-type DBDDL struct{}
+type DBDDL struct {
+	createDbLock *sync.Mutex
+}
 
 // CreateDatabase implements the engine.DBDDLPlugin interface
 func (plugin *DBDDL) CreateDatabase(ctx context.Context, name string) error {
@@ -39,6 +42,8 @@ func (plugin *DBDDL) CreateDatabase(ctx context.Context, name string) error {
 			Name: "0",
 		}},
 	}
+	plugin.createDbLock.Lock()
+	defer plugin.createDbLock.Unlock()
 	return globalCreateDb(ctx, ks)
 }
 
@@ -49,6 +54,6 @@ func (plugin *DBDDL) DropDatabase(ctx context.Context, name string) error {
 
 func init() {
 	servenv.OnRun(func() {
-		engine.DBDDLRegister("vttest", &DBDDL{})
+		engine.DBDDLRegister("vttest", &DBDDL{createDbLock: &sync.Mutex{}})
 	})
 }


### PR DESCRIPTION
WIP

Example output demonstrating that unique UID wasn't always used and caused errors:

```
gitbackups-vtcombo-1  | I0515 22:54:07.227162       7 syslogger.go:129] gitbackups_test_efDbWJRM [keyspace] created value:
gitbackups-vtcombo-1  | I0515 22:54:07.227203       7 locks.go:245] Locking keyspace gitbackups_test_efDbWJRM for action CreateShard
gitbackups-vtcombo-1  | I0515 22:54:07.227250       7 syslogger.go:129] gitbackups_test_efDbWJRM/0 [shard] created value: is_primary_serving:true
gitbackups-vtcombo-1  | I0515 22:54:07.227255       7 locks.go:284] Unlocking keyspace gitbackups_test_efDbWJRM for successful action CreateShard
gitbackups-vtcombo-1  | I0515 22:54:07.234657       7 tablet_map.go:90] Creating PRIMARY tablet test-0000000028 for gitbackups_test_efDbWJRM/0
...
gitbackups-vtcombo-1  | I0515 22:54:07.257710       7 syslogger.go:129] gitbackups_test_eIzZi1RE [keyspace] created value:
gitbackups-vtcombo-1  | I0515 22:54:07.258008       7 locks.go:245] Locking keyspace gitbackups_test_eIzZi1RE for action CreateShard
gitbackups-vtcombo-1  | I0515 22:54:07.258269       7 syslogger.go:129] gitbackups_test_eIzZi1RE/0 [shard] created value: is_primary_serving:true
gitbackups-vtcombo-1  | I0515 22:54:07.258384       7 locks.go:284] Unlocking keyspace gitbackups_test_eIzZi1RE for successful action CreateShard
...
gitbackups-vtcombo-1  | I0515 22:54:07.278880       7 tablet_map.go:90] Creating PRIMARY tablet test-0000000028 for gitbackups_test_eIzZi1RE/0
...
gitbackups-vtcombo-1  | E0515 22:54:07.285483       7 vtgate.go:607] Execute: initTablet failed because existing tablet keyspace and shard gitbackups_test_efDbWJRM/0 differ from the provided ones gitbackups_test_eIzZi1RE/0, request: map[BindVariables:map[] Session:autocommit:true options:{included_fields:ALL workload:OLTP} row_count:-1 DDLStrategy:"direct" SessionUUID:"65c55f97-f373-11ed-97bd-0242ac160003" enable_system_settings:true Sql:CREATE DATABASE `gitbackups_test_eIzZi1RE`]

```

Specifically can see that database `gitbackups_test_efDbWJRM` made a tablet with UID 28:

> Creating PRIMARY tablet test-0000000028 for **gitbackups_test_efDbWJRM/0**

But then `gitbackups_test_eIzZi1RE` also then tries to create a tablet with UID 28:

> Creating PRIMARY tablet test-0000000028 for **gitbackups_test_eIzZi1RE/0**

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
