### PR TITLE
Backport #16129 and #16159 to v16

### DIFF
--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -207,9 +207,9 @@ SELECT id FROM orders WHERE id IN (1, "1", 1)
 2 ks_sharded/40-80: select id from orders where id in (1, '1', 1) limit 10001
 
 ----------------------------------------------------------------------
-(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 2)
+(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 3)
 
-2 ks_sharded/-40: select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where `user`.id = 2 limit 10001
-2 ks_sharded/-40: select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where `user`.id = 1 limit 10001
+1 ks_sharded/-40: select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where `user`.id = 1 limit 10001
+1 ks_sharded/40-80: select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where `user`.id = 3 limit 10001
 
 ----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
+++ b/go/vt/vtexplain/testdata/multi-output/selectsharded-output.txt
@@ -207,3 +207,9 @@ SELECT id FROM orders WHERE id IN (1, "1", 1)
 2 ks_sharded/40-80: select id from orders where id in (1, '1', 1) limit 10001
 
 ----------------------------------------------------------------------
+(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 2)
+
+2 ks_sharded/-40: select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where `user`.id = 2 limit 10001
+2 ks_sharded/-40: select distinct `user`.id, `user`.`name`, weight_string(`user`.id), weight_string(`user`.`name`) from `user` where `user`.id = 1 limit 10001
+
+----------------------------------------------------------------------

--- a/go/vt/vtexplain/testdata/selectsharded-queries.sql
+++ b/go/vt/vtexplain/testdata/selectsharded-queries.sql
@@ -40,4 +40,4 @@ SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id
 
 SELECT id FROM orders WHERE id IN (1, "1", 1);
 
-(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 2);
+(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 3);

--- a/go/vt/vtexplain/testdata/selectsharded-queries.sql
+++ b/go/vt/vtexplain/testdata/selectsharded-queries.sql
@@ -38,4 +38,6 @@ select id from user where not id in (select col from music where music.user_id =
 
 SELECT user.id, user.name, name_info.info FROM user INNER JOIN music ON (user.id = music.user_id) LEFT OUTER JOIN name_info ON (user.name = name_info.name);
 
-SELECT id FROM orders WHERE id IN (1, "1", 1)
+SELECT id FROM orders WHERE id IN (1, "1", 1);
+
+(SELECT user.id, user.name FROM user WHERE user.id = 1) UNION (SELECT user.id, user.name FROM user WHERE user.id = 2);

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -794,9 +794,15 @@ func inferColTypeFromExpr(node sqlparser.Expr, tableColumnMap map[sqlparser.Iden
 			colTypes = append(colTypes, colType)
 		}
 	case sqlparser.Callable:
-		// As a shortcut, functions are integral types
-		colNames = append(colNames, sqlparser.String(node))
-		colTypes = append(colTypes, querypb.Type_INT32)
+		switch node := node.(type) {
+		case *sqlparser.WeightStringFuncExpr:
+			colNames = append(colNames, sqlparser.String(node))
+			colTypes = append(colTypes, querypb.Type_BINARY)
+		default:
+			// As a shortcut, functions are integral types
+			colNames = append(colNames, sqlparser.String(node))
+			colTypes = append(colTypes, querypb.Type_INT32)
+		}
 	case *sqlparser.Literal:
 		colNames = append(colNames, sqlparser.String(node))
 		switch node.Type {


### PR DESCRIPTION
## Description

This backports #16129 and #16159 into our v16 branch.

---

This fixes an issue with `vtexplain` when used to generate the query plans for `UNION` queries with `weight_string` function calls. 

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
