### PR TITLE
Add hotfix to make vitess v15 compile under go 1.23

### DIFF
--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -24,12 +24,24 @@ source $DIR/shell_functions.inc
 DEFAULT_BUILD_GIT_REV=$(git rev-parse HEAD)
 DEFAULT_BUILD_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-echo "\
-  -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
-  -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
-  -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
-  -checklinkname=0
-"
+GO_MINOR_VER=$(go version | cut -d ' ' -f 3 | cut -d '.' -f 2)
+if [[ $((GO_MINOR_VER)) -ge 23 ]]; then
+  echo "\
+    -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
+    -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
+    -checklinkname=0
+  "
+else
+  echo "\
+    -X 'vitess.io/vitess/go/vt/servenv.buildHost=$(hostname)' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildUser=$(whoami)' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildGitRev=${BUILD_GIT_REV:-$DEFAULT_BUILD_GIT_REV}' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
+    -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
+    -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
+  "
+fi

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,4 +31,5 @@ echo "\
   -X 'vitess.io/vitess/go/vt/servenv.buildGitBranch=${BUILD_GIT_BRANCH:-$DEFAULT_BUILD_GIT_BRANCH}' \
   -X 'vitess.io/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
   -X 'vitess.io/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
+  -checklinkname=0
 "


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->
 see https://github.com/github/vitess/issues/1207

This PR adds `-checklinkname=0` to the build script for vitess to allow it to compile under go 1.23

There are some enterprise backports that still pull v15, which is why this was made.

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
