### PR TITLE
Backport fix for CVE-2024-53257 to `release-18.0-github`

### DIFF
--- a/go/vt/vtgate/debugenv.go
+++ b/go/vt/vtgate/debugenv.go
@@ -22,8 +22,9 @@ import (
 	"html"
 	"net/http"
 	"strconv"
-	"text/template"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/discovery"

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -20,15 +20,15 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
-	"vitess.io/vitess/go/vt/vtgate/logstats"
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"
 	"vitess.io/vitess/go/vt/logz"
 	"vitess.io/vitess/go/vt/sqlparser"
+	"vitess.io/vitess/go/vt/vtgate/logstats"
 )
 
 var (

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestQuerylogzHandlerFormatting(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
-	logStats := logstats.NewLogStats(context.Background(), "Execute", "select name from test_table limit 1000", "suuid", nil)
+	logStats := logstats.NewLogStats(context.Background(), "Execute", "select name, 'inject <script>alert();</script>' from test_table limit 1000", "suuid", nil)
 	logStats.StmtType = "select"
 	logStats.RowsAffected = 1000
 	logStats.ShardQueries = 1
@@ -63,7 +63,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 		`<td>0.002</td>`,
 		`<td>0.003</td>`,
 		`<td>select</td>`,
-		`<td>select name from test_table limit 1000</td>`,
+		regexp.QuoteMeta(`<td>select name,​ &#39;inject &lt;script&gt;alert()​;&lt;/script&gt;&#39; from test_table limit 1000</td>`),
 		`<td>1</td>`,
 		`<td>1000</td>`,
 		`<td></td>`,
@@ -93,7 +93,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 		`<td>0.002</td>`,
 		`<td>0.003</td>`,
 		`<td>select</td>`,
-		`<td>select name from test_table limit 1000</td>`,
+		regexp.QuoteMeta(`<td>select name,​ &#39;inject &lt;script&gt;alert()​;&lt;/script&gt;&#39; from test_table limit 1000</td>`),
 		`<td>1</td>`,
 		`<td>1000</td>`,
 		`<td></td>`,
@@ -123,7 +123,7 @@ func TestQuerylogzHandlerFormatting(t *testing.T) {
 		`<td>0.002</td>`,
 		`<td>0.003</td>`,
 		`<td>select</td>`,
-		`<td>select name from test_table limit 1000</td>`,
+		regexp.QuoteMeta(`<td>select name,​ &#39;inject &lt;script&gt;alert()​;&lt;/script&gt;&#39; from test_table limit 1000</td>`),
 		`<td>1</td>`,
 		`<td>1000</td>`,
 		`<td></td>`,

--- a/go/vt/vttablet/tabletserver/debugenv.go
+++ b/go/vt/vttablet/tabletserver/debugenv.go
@@ -22,8 +22,9 @@ import (
 	"html"
 	"net/http"
 	"strconv"
-	"text/template"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
+
+	"github.com/google/safehtml/template"
 
 	"vitess.io/vitess/go/acl"
 	"vitess.io/vitess/go/vt/log"

--- a/go/vt/vttablet/tabletserver/querylogz_test.go
+++ b/go/vt/vttablet/tabletserver/querylogz_test.go
@@ -36,7 +36,7 @@ func TestQuerylogzHandler(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
 	logStats := tabletenv.NewLogStats(context.Background(), "Execute")
 	logStats.PlanType = planbuilder.PlanSelect.String()
-	logStats.OriginalSQL = "select name from test_table limit 1000"
+	logStats.OriginalSQL = "select name, 'inject <script>alert();</script>' from test_table limit 1000"
 	logStats.RowsAffected = 1000
 	logStats.NumberOfQueries = 1
 	logStats.StartTime, _ = time.Parse("Jan 2 15:04:05", "Nov 29 13:33:09")
@@ -63,7 +63,7 @@ func TestQuerylogzHandler(t *testing.T) {
 		`<td>0.001</td>`,
 		`<td>1e-08</td>`,
 		`<td>Select</td>`,
-		`<td>select name from test_table limit 1000</td>`,
+		regexp.QuoteMeta(`<td>select name,​ &#39;inject &lt;script&gt;alert()​;&lt;/script&gt;&#39; from test_table limit 1000</td>`),
 		`<td>1</td>`,
 		`<td>none</td>`,
 		`<td>1000</td>`,
@@ -94,7 +94,7 @@ func TestQuerylogzHandler(t *testing.T) {
 		`<td>0.001</td>`,
 		`<td>1e-08</td>`,
 		`<td>Select</td>`,
-		`<td>select name from test_table limit 1000</td>`,
+		regexp.QuoteMeta(`<td>select name,​ &#39;inject &lt;script&gt;alert()​;&lt;/script&gt;&#39; from test_table limit 1000</td>`),
 		`<td>1</td>`,
 		`<td>none</td>`,
 		`<td>1000</td>`,
@@ -125,7 +125,7 @@ func TestQuerylogzHandler(t *testing.T) {
 		`<td>0.001</td>`,
 		`<td>1e-08</td>`,
 		`<td>Select</td>`,
-		`<td>select name from test_table limit 1000</td>`,
+		regexp.QuoteMeta(`<td>select name,​ &#39;inject &lt;script&gt;alert()​;&lt;/script&gt;&#39; from test_table limit 1000</td>`),
 		`<td>1</td>`,
 		`<td>none</td>`,
 		`<td>1000</td>`,


### PR DESCRIPTION
These templates were rendered using text/template which is fundamentally broken as it would allow for trivial HTML injection.

Instead render using safehtml/template so that we have automatic escaping.

--- 

This is backporting the fix for CVE-2024-53257 to `release-18.0-github`.

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
