### PR TITLE
VReplication: Support reversing read-only traffic in vtctldclient (#1…

### DIFF
--- a/go/test/endtoend/vreplication/helper_test.go
+++ b/go/test/endtoend/vreplication/helper_test.go
@@ -339,8 +339,11 @@ func executeOnTablet(t *testing.T, conn *mysql.Conn, tablet *cluster.VttabletPro
 
 func assertQueryExecutesOnTablet(t *testing.T, conn *mysql.Conn, tablet *cluster.VttabletProcess, ksName string, query string, matchQuery string) {
 	t.Helper()
+	rr, err := vc.VtctldClient.ExecuteCommandWithOutput("GetRoutingRules")
+	require.NoError(t, err)
 	count0, body0, count1, body1 := executeOnTablet(t, conn, tablet, ksName, query, matchQuery)
-	assert.Equalf(t, count0+1, count1, "query %q did not execute in target;\ntried to match %q\nbefore:\n%s\n\nafter:\n%s\n\n", query, matchQuery, body0, body1)
+	require.Equalf(t, count0+1, count1, "query %q did not execute on destination %s (%s-%d);\ntried to match %q\nbefore:\n%s\n\nafter:\n%s\n\nrouting rules:\n%s\n\n",
+		query, ksName, tablet.Cell, tablet.TabletUID, matchQuery, body0, body1, rr)
 }
 
 func assertQueryDoesNotExecutesOnTablet(t *testing.T, conn *mysql.Conn, tablet *cluster.VttabletProcess, ksName string, query string, matchQuery string) {

--- a/go/test/endtoend/vreplication/movetables_buffering_test.go
+++ b/go/test/endtoend/vreplication/movetables_buffering_test.go
@@ -12,7 +12,14 @@ import (
 )
 
 func TestMoveTablesBuffering(t *testing.T) {
-	defaultRdonly = 1
+	ogReplicas := defaultReplicas
+	ogRdOnly := defaultRdonly
+	defer func() {
+		defaultReplicas = ogReplicas
+		defaultRdonly = ogRdOnly
+	}()
+	defaultRdonly = 0
+	defaultReplicas = 0
 	vc = setupMinimalCluster(t)
 	defer vc.TearDown()
 

--- a/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
+++ b/go/test/endtoend/vreplication/resharding_workflows_v2_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -31,9 +32,11 @@ import (
 
 	"vitess.io/vitess/go/test/endtoend/cluster"
 	"vitess.io/vitess/go/vt/log"
+	"vitess.io/vitess/go/vt/topo/topoproto"
 	"vitess.io/vitess/go/vt/wrangler"
 
 	binlogdatapb "vitess.io/vitess/go/vt/proto/binlogdata"
+	topodatapb "vitess.io/vitess/go/vt/proto/topodata"
 	vtctldatapb "vitess.io/vitess/go/vt/proto/vtctldata"
 )
 
@@ -163,9 +166,7 @@ func tstWorkflowExec(t *testing.T, cells, workflow, sourceKs, targetKs, tables, 
 		args = append(args, "--tablet-types", tabletTypes)
 	}
 	args = append(args, "--action_timeout=10m") // At this point something is up so fail the test
-	if debugMode {
-		t.Logf("Executing workflow command: vtctldclient %v", strings.Join(args, " "))
-	}
+	t.Logf("Executing workflow command: vtctldclient %s", strings.Join(args, " "))
 	output, err := vc.VtctldClient.ExecuteCommandWithOutput(args...)
 	lastOutput = output
 	if err != nil {
@@ -326,27 +327,45 @@ func tstWorkflowCancel(t *testing.T) error {
 	return tstWorkflowAction(t, workflowActionCancel, "", "")
 }
 
-func validateReadsRoute(t *testing.T, tabletTypes string, tablet *cluster.VttabletProcess) {
-	if tabletTypes == "" {
-		tabletTypes = "replica,rdonly"
+func validateReadsRoute(t *testing.T, tabletType string, tablet *cluster.VttabletProcess) {
+	if tablet == nil {
+		return
 	}
 	vtgateConn, closeConn := getVTGateConn()
 	defer closeConn()
-	for _, tt := range []string{"replica", "rdonly"} {
-		destination := fmt.Sprintf("%s:%s@%s", tablet.Keyspace, tablet.Shard, tt)
-		if strings.Contains(tabletTypes, tt) {
-			readQuery := "select * from customer"
-			assertQueryExecutesOnTablet(t, vtgateConn, tablet, destination, readQuery, readQuery)
-		}
-	}
+	// We do NOT want to target a shard as that goes around the routing rules and
+	// defeats the purpose here. We are using a query w/o a WHERE clause so for
+	// sharded keyspaces it should hit all shards as a SCATTER query. So all we
+	// care about is the keyspace and tablet type.
+	destination := fmt.Sprintf("%s@%s", tablet.Keyspace, strings.ToLower(tabletType))
+	readQuery := "select cid from customer limit 50"
+	assertQueryExecutesOnTablet(t, vtgateConn, tablet, destination, readQuery, "select cid from customer limit :vtg1")
 }
 
 func validateReadsRouteToSource(t *testing.T, tabletTypes string) {
-	validateReadsRoute(t, tabletTypes, sourceReplicaTab)
+	tt, err := topoproto.ParseTabletTypes(tabletTypes)
+	require.NoError(t, err)
+	if slices.Contains(tt, topodatapb.TabletType_REPLICA) {
+		require.NotNil(t, sourceReplicaTab)
+		validateReadsRoute(t, topodatapb.TabletType_REPLICA.String(), sourceReplicaTab)
+	}
+	if slices.Contains(tt, topodatapb.TabletType_RDONLY) {
+		require.NotNil(t, sourceRdonlyTab)
+		validateReadsRoute(t, topodatapb.TabletType_RDONLY.String(), sourceRdonlyTab)
+	}
 }
 
 func validateReadsRouteToTarget(t *testing.T, tabletTypes string) {
-	validateReadsRoute(t, tabletTypes, targetReplicaTab1)
+	tt, err := topoproto.ParseTabletTypes(tabletTypes)
+	require.NoError(t, err)
+	if slices.Contains(tt, topodatapb.TabletType_REPLICA) {
+		require.NotNil(t, targetReplicaTab1)
+		validateReadsRoute(t, topodatapb.TabletType_REPLICA.String(), targetReplicaTab1)
+	}
+	if slices.Contains(tt, topodatapb.TabletType_RDONLY) {
+		require.NotNil(t, targetRdonlyTab1)
+		validateReadsRoute(t, topodatapb.TabletType_RDONLY.String(), targetRdonlyTab1)
+	}
 }
 
 func validateWritesRouteToSource(t *testing.T) {
@@ -396,6 +415,13 @@ func getCurrentStatus(t *testing.T) string {
 // but CI currently fails on creating multiple clusters even after the previous ones are torn down
 
 func TestBasicV2Workflows(t *testing.T) {
+	ogReplicas := defaultReplicas
+	ogRdOnly := defaultRdonly
+	defer func() {
+		defaultReplicas = ogReplicas
+		defaultRdonly = ogRdOnly
+	}()
+	defaultReplicas = 1
 	defaultRdonly = 1
 	extraVTTabletArgs = []string{
 		parallelInsertWorkers,
@@ -633,6 +659,12 @@ func testPartialSwitches(t *testing.T) {
 	tstWorkflowSwitchReads(t, "", "")
 	checkStates(t, nextState, nextState) // idempotency
 
+	tstWorkflowReverseReads(t, "replica,rdonly", "")
+	checkStates(t, wrangler.WorkflowStateReadsSwitched, wrangler.WorkflowStateNotSwitched)
+
+	tstWorkflowSwitchReads(t, "", "")
+	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateReadsSwitched)
+
 	tstWorkflowSwitchWrites(t)
 	currentState = nextState
 	nextState = wrangler.WorkflowStateAllSwitched
@@ -669,12 +701,12 @@ func testRestOfWorkflow(t *testing.T) {
 	waitForLowLag(t, "customer", "wf1")
 	tstWorkflowSwitchReads(t, "", "")
 	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateReadsSwitched)
-	validateReadsRouteToTarget(t, "replica")
+	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
 	tstWorkflowSwitchWrites(t)
 	checkStates(t, wrangler.WorkflowStateReadsSwitched, wrangler.WorkflowStateAllSwitched)
-	validateReadsRouteToTarget(t, "replica")
+	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToTarget(t)
 
 	// this function is called for both MoveTables and Reshard, so the reverse workflows exist in different keyspaces
@@ -685,42 +717,45 @@ func testRestOfWorkflow(t *testing.T) {
 	waitForLowLag(t, keyspace, "wf1_reverse")
 	tstWorkflowReverseReads(t, "", "")
 	checkStates(t, wrangler.WorkflowStateAllSwitched, wrangler.WorkflowStateWritesSwitched)
-	validateReadsRouteToSource(t, "replica")
+	validateReadsRouteToSource(t, "replica,rdonly")
 	validateWritesRouteToTarget(t)
 
 	tstWorkflowReverseWrites(t)
 	checkStates(t, wrangler.WorkflowStateWritesSwitched, wrangler.WorkflowStateNotSwitched)
-	validateReadsRouteToSource(t, "replica")
+	validateReadsRouteToSource(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
 	waitForLowLag(t, "customer", "wf1")
 	tstWorkflowSwitchWrites(t)
 	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateWritesSwitched)
-	validateReadsRouteToSource(t, "replica")
+	validateReadsRouteToSource(t, "replica,rdonly")
 	validateWritesRouteToTarget(t)
 
 	waitForLowLag(t, keyspace, "wf1_reverse")
 	tstWorkflowReverseWrites(t)
-	validateReadsRouteToSource(t, "replica")
+	checkStates(t, wrangler.WorkflowStateWritesSwitched, wrangler.WorkflowStateNotSwitched)
+	validateReadsRouteToSource(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
 	waitForLowLag(t, "customer", "wf1")
 	tstWorkflowSwitchReads(t, "", "")
-	validateReadsRouteToTarget(t, "replica")
+	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateReadsSwitched)
+	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
 	tstWorkflowReverseReads(t, "", "")
-	validateReadsRouteToSource(t, "replica")
+	checkStates(t, wrangler.WorkflowStateReadsSwitched, wrangler.WorkflowStateNotSwitched)
+	validateReadsRouteToSource(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
 	tstWorkflowSwitchReadsAndWrites(t)
-	validateReadsRouteToTarget(t, "replica")
-	validateReadsRoute(t, "rdonly", targetRdonlyTab1)
+	checkStates(t, wrangler.WorkflowStateNotSwitched, wrangler.WorkflowStateAllSwitched)
+	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToTarget(t)
 	waitForLowLag(t, keyspace, "wf1_reverse")
 	tstWorkflowReverseReadsAndWrites(t)
-	validateReadsRoute(t, "rdonly", sourceRdonlyTab)
-	validateReadsRouteToSource(t, "replica")
+	checkStates(t, wrangler.WorkflowStateAllSwitched, wrangler.WorkflowStateNotSwitched)
+	validateReadsRouteToSource(t, "replica,rdonly")
 	validateWritesRouteToSource(t)
 
 	// trying to complete an unswitched workflow should error
@@ -731,8 +766,7 @@ func testRestOfWorkflow(t *testing.T) {
 	// fully switch and complete
 	waitForLowLag(t, "customer", "wf1")
 	tstWorkflowSwitchReadsAndWrites(t)
-	validateReadsRoute(t, "rdonly", targetRdonlyTab1)
-	validateReadsRouteToTarget(t, "replica")
+	validateReadsRouteToTarget(t, "replica,rdonly")
 	validateWritesRouteToTarget(t)
 
 	err = tstWorkflowComplete(t)
@@ -787,7 +821,7 @@ func setupMinimalCluster(t *testing.T) *VitessCluster {
 
 	zone1 := vc.Cells["zone1"]
 
-	vc.AddKeyspace(t, []*Cell{zone1}, "product", "0", initialProductVSchema, initialProductSchema, 0, 0, 100, nil)
+	vc.AddKeyspace(t, []*Cell{zone1}, "product", "0", initialProductVSchema, initialProductSchema, defaultReplicas, defaultRdonly, 100, nil)
 
 	verifyClusterHealth(t, vc)
 	insertInitialData(t)
@@ -800,7 +834,7 @@ func setupMinimalCluster(t *testing.T) *VitessCluster {
 func setupMinimalCustomerKeyspace(t *testing.T) map[string]*cluster.VttabletProcess {
 	tablets := make(map[string]*cluster.VttabletProcess)
 	if _, err := vc.AddKeyspace(t, []*Cell{vc.Cells["zone1"]}, "customer", "-80,80-",
-		customerVSchema, customerSchema, 0, 0, 200, nil); err != nil {
+		customerVSchema, customerSchema, defaultReplicas, defaultRdonly, 200, nil); err != nil {
 		t.Fatal(err)
 	}
 	defaultCell := vc.Cells[vc.CellNames[0]]
@@ -936,6 +970,7 @@ func createAdditionalCustomerShards(t *testing.T, shards string) {
 	targetTab2 = custKs.Shards["80-c0"].Tablets["zone1-600"].Vttablet
 	targetTab1 = custKs.Shards["40-80"].Tablets["zone1-500"].Vttablet
 	targetReplicaTab1 = custKs.Shards["-40"].Tablets["zone1-401"].Vttablet
+	targetRdonlyTab1 = custKs.Shards["-40"].Tablets["zone1-402"].Vttablet
 
 	sourceTab = custKs.Shards["-80"].Tablets["zone1-200"].Vttablet
 	sourceReplicaTab = custKs.Shards["-80"].Tablets["zone1-201"].Vttablet
@@ -946,4 +981,35 @@ func tstApplySchemaOnlineDDL(t *testing.T, sql string, keyspace string) {
 	err := vc.VtctldClient.ExecuteCommand("ApplySchema", "--ddl-strategy=online",
 		"--sql", sql, keyspace)
 	require.NoError(t, err, fmt.Sprintf("ApplySchema Error: %s", err))
+}
+
+func validateTableRoutingRule(t *testing.T, table, tabletType, fromKeyspace, toKeyspace string) {
+	tabletType = strings.ToLower(strings.TrimSpace(tabletType))
+	rr := getRoutingRules(t)
+	// We set matched = true by default because it is possible, if --no-routing-rules is set while creating
+	// a workflow, that the routing rules are empty when the workflow starts.
+	// We set it to false below when the rule is found, but before matching the routed keyspace.
+	matched := true
+	for _, r := range rr.GetRules() {
+		fromRule := fmt.Sprintf("%s.%s", fromKeyspace, table)
+		if tabletType != "" && tabletType != "primary" {
+			fromRule = fmt.Sprintf("%s@%s", fromRule, tabletType)
+		}
+		if r.FromTable == fromRule {
+			// We found the rule, so we can set matched to false here and check for the routed keyspace below.
+			matched = false
+			require.NotEmpty(t, r.ToTables)
+			toTable := r.ToTables[0]
+			// The ToTables value is of the form "routedKeyspace.table".
+			routedKeyspace, routedTable, ok := strings.Cut(toTable, ".")
+			require.True(t, ok)
+			require.Equal(t, table, routedTable)
+			if routedKeyspace == toKeyspace {
+				// We found the rule, the table and keyspace matches, so our search is done.
+				matched = true
+				break
+			}
+		}
+	}
+	require.Truef(t, matched, "routing rule for %s.%s from %s to %s not found", fromKeyspace, table, tabletType, toKeyspace)
 }

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -258,13 +258,15 @@ func (v VtctldMoveTables) Status() {
 }
 
 func (v VtctldMoveTables) SwitchReads() {
-	//TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic", "--tablet-types=rdonly,replica"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldMoveTables) SwitchWrites() {
-	//TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic", "--tablet-types=primary"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldMoveTables) ReverseReads() {

--- a/go/test/endtoend/vreplication/wrappers_test.go
+++ b/go/test/endtoend/vreplication/wrappers_test.go
@@ -19,6 +19,7 @@ package vreplication
 import (
 	"math/rand"
 	"strconv"
+	"strings"
 
 	"github.com/stretchr/testify/require"
 
@@ -32,12 +33,15 @@ type iWorkflow interface {
 	SwitchReads()
 	SwitchWrites()
 	SwitchReadsAndWrites()
+	ReverseReads()
+	ReverseWrites()
 	ReverseReadsAndWrites()
 	Cancel()
 	Complete()
 	Flavor() string
 	GetLastOutput() string
 	Start()
+	Status()
 	Stop()
 }
 
@@ -138,6 +142,11 @@ func (vmt *VtctlMoveTables) Show() {
 	panic("implement me")
 }
 
+func (vmt *VtctlMoveTables) Status() {
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_MoveTables
+	vmt.exec("Status")
+}
+
 func (vmt *VtctlMoveTables) exec(action string) {
 	options := &workflowExecOptions{
 		deferSecondaryKeys: false,
@@ -148,13 +157,26 @@ func (vmt *VtctlMoveTables) exec(action string) {
 	require.NoError(vmt.vc.t, err)
 }
 func (vmt *VtctlMoveTables) SwitchReads() {
-	//TODO implement me
-	panic("implement me")
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionSwitchTraffic, "replica,rdonly", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
 }
 
 func (vmt *VtctlMoveTables) SwitchWrites() {
-	//TODO implement me
-	panic("implement me")
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionSwitchTraffic, "primary", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
+}
+func (vmt *VtctlMoveTables) ReverseReads() {
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionReverseTraffic, "replica,rdonly", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
+}
+
+func (vmt *VtctlMoveTables) ReverseWrites() {
+	err := tstWorkflowExecVtctl(vmt.vc.t, "", vmt.workflowName, vmt.sourceKeyspace, vmt.targetKeyspace,
+		vmt.tables, workflowActionReverseTraffic, "primary", "", "", defaultWorkflowExecOptions)
+	require.NoError(vmt.vc.t, err)
 }
 
 func (vmt *VtctlMoveTables) Cancel() {
@@ -195,9 +217,9 @@ func (v VtctldMoveTables) exec(args ...string) {
 	args2 := []string{"MoveTables", "--workflow=" + v.workflowName, "--target-keyspace=" + v.targetKeyspace}
 	args2 = append(args2, args...)
 	var err error
-	if v.lastOutput, err = vc.VtctldClient.ExecuteCommandWithOutput(args2...); err != nil {
-		require.FailNowf(v.vc.t, "failed MoveTables action", "%v: %s", err, v.lastOutput)
-	}
+	v.vc.t.Logf("Executing workflow command: vtctldclient %s", strings.Join(args2, " "))
+	v.lastOutput, err = vc.VtctldClient.ExecuteCommandWithOutput(args2...)
+	require.NoError(v.vc.t, err, "failed MoveTables action, error: %v: output: %s", err, v.lastOutput)
 }
 
 func (v VtctldMoveTables) Create() {
@@ -231,6 +253,10 @@ func (v VtctldMoveTables) Show() {
 	v.exec("Show")
 }
 
+func (v VtctldMoveTables) Status() {
+	v.exec("Status")
+}
+
 func (v VtctldMoveTables) SwitchReads() {
 	//TODO implement me
 	panic("implement me")
@@ -239,6 +265,18 @@ func (v VtctldMoveTables) SwitchReads() {
 func (v VtctldMoveTables) SwitchWrites() {
 	//TODO implement me
 	panic("implement me")
+}
+
+func (v VtctldMoveTables) ReverseReads() {
+	args := []string{"ReverseTraffic", "--tablet-types=rdonly,replica"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
+}
+
+func (v VtctldMoveTables) ReverseWrites() {
+	args := []string{"ReverseTraffic", "--tablet-types=primary"}
+	args = append(args, v.switchFlags...)
+	v.exec(args...)
 }
 
 func (v VtctldMoveTables) Cancel() {
@@ -305,6 +343,16 @@ type VtctlReshard struct {
 	*reshardWorkflow
 }
 
+func (vrs *VtctlReshard) ReverseReads() {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (vrs *VtctlReshard) ReverseWrites() {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (vrs *VtctlReshard) Flavor() string {
 	return "vtctl"
 }
@@ -316,6 +364,16 @@ func newVtctlReshard(rs *reshardWorkflow) *VtctlReshard {
 func (vrs *VtctlReshard) Create() {
 	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_Reshard
 	vrs.exec(workflowActionCreate)
+}
+
+func (vrs *VtctlReshard) MirrorTraffic() {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (vrs *VtctlReshard) Status() {
+	currentWorkflowType = binlogdatapb.VReplicationWorkflowType_Reshard
+	vrs.exec("Status")
 }
 
 func (vrs *VtctlReshard) SwitchReadsAndWrites() {
@@ -386,9 +444,9 @@ func (v VtctldReshard) exec(args ...string) {
 	args2 := []string{"Reshard", "--workflow=" + v.workflowName, "--target-keyspace=" + v.targetKeyspace}
 	args2 = append(args2, args...)
 	var err error
-	if v.lastOutput, err = vc.VtctldClient.ExecuteCommandWithOutput(args2...); err != nil {
-		v.vc.t.Fatalf("failed to create Reshard workflow: %v: %s", err, v.lastOutput)
-	}
+	v.vc.t.Logf("Executing command: vtctldclient %s", strings.Join(args2, " "))
+	v.lastOutput, err = vc.VtctldClient.ExecuteCommandWithOutput(args2...)
+	require.NoError(v.vc.t, err, "failed Reshard action, error: %v: output: %s", err, v.lastOutput)
 }
 
 func (v VtctldReshard) Create() {
@@ -420,14 +478,36 @@ func (v VtctldReshard) Show() {
 	v.exec("Show")
 }
 
+func (v *VtctldReshard) Status() {
+	v.exec("Status")
+}
+
 func (v VtctldReshard) SwitchReads() {
-	//TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=rdonly,replica")
+	v.exec(args...)
 }
 
 func (v VtctldReshard) SwitchWrites() {
-	//TODO implement me
-	panic("implement me")
+	args := []string{"SwitchTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=primary")
+	v.exec(args...)
+}
+
+func (v VtctldReshard) ReverseReads() {
+	args := []string{"ReverseTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=rdonly,replica")
+	v.exec(args...)
+}
+
+func (v VtctldReshard) ReverseWrites() {
+	args := []string{"ReverseTraffic"}
+	args = append(args, v.switchFlags...)
+	args = append(args, "--tablet-types=primary")
+	v.exec(args...)
 }
 
 func (v VtctldReshard) Cancel() {

--- a/go/vt/vtctl/workflow/server.go
+++ b/go/vt/vtctl/workflow/server.go
@@ -2942,10 +2942,20 @@ func (s *Server) finalizeMigrateWorkflow(ctx context.Context, targetKeyspace, wo
 
 // WorkflowSwitchTraffic switches traffic in the direction passed for specified tablet types.
 func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.WorkflowSwitchTrafficRequest) (*vtctldatapb.WorkflowSwitchTrafficResponse, error) {
+	span, ctx := trace.NewSpan(ctx, "workflow.Server.WorkflowSwitchTraffic")
+	defer span.Finish()
+
+	span.Annotate("keyspace", req.Keyspace)
+	span.Annotate("workflow", req.Workflow)
+	span.Annotate("tablet-types", req.TabletTypes)
+	span.Annotate("direction", req.Direction)
+	span.Annotate("enable-reverse-replication", req.EnableReverseReplication)
+	span.Annotate("shards", req.Shards)
+
 	var (
-		dryRunResults                     []string
-		rdDryRunResults, wrDryRunResults  *[]string
-		hasReplica, hasRdonly, hasPrimary bool
+		dryRunResults                              []string
+		rdDryRunResults, wrDryRunResults           *[]string
+		switchReplica, switchRdonly, switchPrimary bool
 	)
 	timeout, set, err := protoutil.DurationFromProto(req.Timeout)
 	if err != nil {
@@ -2954,6 +2964,19 @@ func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.Wor
 	}
 	if !set {
 		timeout = defaultDuration
+	}
+	maxReplicationLagAllowed, set, err := protoutil.DurationFromProto(req.MaxReplicationLagAllowed)
+	if err != nil {
+		err = vterrors.Wrapf(err, "unable to parse MaxReplicationLagAllowed into a valid duration")
+		return nil, err
+	}
+	if !set {
+		maxReplicationLagAllowed = defaultDuration
+	}
+	direction := TrafficSwitchDirection(req.Direction)
+	switchReplica, switchRdonly, switchPrimary, err = parseTabletTypes(req.TabletTypes)
+	if err != nil {
+		return nil, err
 	}
 	ts, startState, err := s.getWorkflowState(ctx, req.Keyspace, req.Workflow)
 	if err != nil {
@@ -2964,36 +2987,43 @@ func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.Wor
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid action for Migrate workflow: SwitchTraffic")
 	}
 
-	maxReplicationLagAllowed, set, err := protoutil.DurationFromProto(req.MaxReplicationLagAllowed)
-	if err != nil {
-		err = vterrors.Wrapf(err, "unable to parse MaxReplicationLagAllowed into a valid duration")
-		return nil, err
-	}
-	if !set {
-		maxReplicationLagAllowed = defaultDuration
-	}
-	direction := TrafficSwitchDirection(req.Direction)
-	if direction == DirectionBackward {
-		ts, startState, err = s.getWorkflowState(ctx, startState.SourceKeyspace, ts.reverseWorkflow)
+	// We need this to know when there isn't a (non-FROZEN) reverse workflow to use.
+	onlySwitchingReads := !startState.WritesSwitched && !switchPrimary
+
+	// We need this for idempotency and to avoid unnecessary work and resulting risk.
+	writesAlreadySwitched := (direction == DirectionForward && startState.WritesSwitched) ||
+		(direction == DirectionBackward && !startState.WritesSwitched)
+
+	if direction == DirectionBackward && !onlySwitchingReads {
+		// This means that the main workflow is FROZEN and the reverse workflow
+		// exists. So we update the starting state so that we're using the reverse
+		// workflow and we can move forward with a normal traffic switch forward
+		// operation, from the reverse workflow's perspective.
+		ts, startState, err = s.getWorkflowState(ctx, ts.sourceKeyspace, ts.reverseWorkflow)
 		if err != nil {
 			return nil, err
 		}
+		direction = DirectionForward
 	}
-	reason, err := s.canSwitch(ctx, ts, startState, direction, int64(maxReplicationLagAllowed.Seconds()), req.Shards)
-	if err != nil {
-		return nil, err
+
+	if writesAlreadySwitched {
+		log.Infof("Writes already switched no need to check lag for the %s.%s workflow",
+			ts.targetKeyspace, ts.workflow)
+	} else {
+		reason, err := s.canSwitch(ctx, ts, int64(maxReplicationLagAllowed.Seconds()), req.GetShards())
+		if err != nil {
+			return nil, err
+		}
+		if reason != "" {
+			return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "cannot switch traffic for workflow %s at this time: %s",
+				startState.Workflow, reason)
+		}
 	}
-	if reason != "" {
-		return nil, vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "cannot switch traffic for workflow %s at this time: %s", startState.Workflow, reason)
-	}
-	hasReplica, hasRdonly, hasPrimary, err = parseTabletTypes(req.TabletTypes)
-	if err != nil {
-		return nil, err
-	}
-	if hasReplica || hasRdonly {
+
+	if switchReplica || switchRdonly {
 		// If we're going to switch writes immediately after then we don't need to
 		// rebuild the SrvVSchema here as we will do it after switching writes.
-		if rdDryRunResults, err = s.switchReads(ctx, req, ts, startState, !hasPrimary /* rebuildSrvVSchema */, direction); err != nil {
+		if rdDryRunResults, err = s.switchReads(ctx, req, ts, startState, !switchPrimary /* rebuildSrvVSchema */, direction); err != nil {
 			return nil, err
 		}
 		log.Infof("Switch Reads done for workflow %s.%s", req.Keyspace, req.Workflow)
@@ -3001,7 +3031,8 @@ func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.Wor
 	if rdDryRunResults != nil {
 		dryRunResults = append(dryRunResults, *rdDryRunResults...)
 	}
-	if hasPrimary {
+
+	if switchPrimary {
 		if _, wrDryRunResults, err = s.switchWrites(ctx, req, ts, timeout, false); err != nil {
 			return nil, err
 		}
@@ -3014,8 +3045,10 @@ func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.Wor
 	if req.DryRun && len(dryRunResults) == 0 {
 		dryRunResults = append(dryRunResults, "No changes required")
 	}
+
 	cmd := "SwitchTraffic"
-	if direction == DirectionBackward {
+	// We must check the original direction requested.
+	if TrafficSwitchDirection(req.Direction) == DirectionBackward {
 		cmd = "ReverseTraffic"
 	}
 	log.Infof("%s done for workflow %s.%s", cmd, req.Keyspace, req.Workflow)
@@ -3026,23 +3059,18 @@ func (s *Server) WorkflowSwitchTraffic(ctx context.Context, req *vtctldatapb.Wor
 	} else {
 		log.Infof("SwitchTraffic done for workflow %s.%s", req.Keyspace, req.Workflow)
 		resp.Summary = fmt.Sprintf("%s was successful for workflow %s.%s", cmd, req.Keyspace, req.Workflow)
-		// Reload the state after the SwitchTraffic operation
-		// and return that as a string.
-		keyspace := req.Keyspace
-		workflow := req.Workflow
-		if direction == DirectionBackward {
-			keyspace = startState.SourceKeyspace
-			workflow = ts.reverseWorkflow
-		}
+		// Reload the state after the SwitchTraffic operation and return that
+		// as a string.
 		resp.StartState = startState.String()
 		log.Infof("Before reloading workflow state after switching traffic: %+v\n", resp.StartState)
-		_, currentState, err := s.getWorkflowState(ctx, keyspace, workflow)
+		_, currentState, err := s.getWorkflowState(ctx, ts.targetKeyspace, ts.workflow)
 		if err != nil {
 			resp.CurrentState = fmt.Sprintf("Error reloading workflow state after switching traffic: %v", err)
 		} else {
 			resp.CurrentState = currentState.String()
 		}
 	}
+
 	return resp, nil
 }
 
@@ -3358,14 +3386,8 @@ func (s *Server) switchWrites(ctx context.Context, req *vtctldatapb.WorkflowSwit
 	return ts.id, sw.logs(), nil
 }
 
-func (s *Server) canSwitch(ctx context.Context, ts *trafficSwitcher, state *State, direction TrafficSwitchDirection,
-	maxAllowedReplLagSecs int64, shards []string) (reason string, err error) {
-	if direction == DirectionForward && state.WritesSwitched ||
-		direction == DirectionBackward && !state.WritesSwitched {
-		log.Infof("writes already switched no need to check lag")
-		return "", nil
-	}
-	wf, err := s.GetWorkflow(ctx, state.TargetKeyspace, state.Workflow, false, shards)
+func (s *Server) canSwitch(ctx context.Context, ts *trafficSwitcher, maxAllowedReplLagSecs int64, shards []string) (reason string, err error) {
+	wf, err := s.GetWorkflow(ctx, ts.targetKeyspace, ts.workflow, false, shards)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
…6920) (#17015)

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
