### PR TITLE
initialize pool from scratch after TableGC.Close

### DIFF
--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -141,12 +141,9 @@ func NewTableGC(env tabletenv.Env, ts *topo.Server, lagThrottler *throttle.Throt
 		throttlerClient: throttle.NewBackgroundClient(lagThrottler, throttlerapp.TableGCName, throttle.ThrottleCheckPrimaryWrite),
 		isOpen:          0,
 
-		env: env,
-		ts:  ts,
-		pool: connpool.NewPool(env, "TableGCPool", tabletenv.ConnPoolConfig{
-			Size:        2,
-			IdleTimeout: env.Config().OltpReadPool.IdleTimeout,
-		}),
+		env:  env,
+		ts:   ts,
+		pool: newPool(env),
 
 		purgingTables:    map[string]bool{},
 		checkRequestChan: make(chan bool),
@@ -173,6 +170,11 @@ func (collector *TableGC) Open() (err error) {
 	}
 	if !collector.env.Config().EnableTableGC {
 		return nil
+	}
+
+	// Reinitialize the pool if it was closed
+	if collector.pool == nil {
+		collector.pool = newPool(collector.env)
 	}
 
 	collector.lifecycleStates, err = schema.ParseGCLifecycle(gcLifecycle)
@@ -227,7 +229,12 @@ func (collector *TableGC) Close() {
 		collector.cancelOperation()
 	}
 	log.Infof("TableGC - closing pool")
-	collector.pool.Close()
+
+	if collector.pool != nil {
+		collector.pool.Close()
+		collector.pool = nil
+	}
+
 	atomic.StoreInt64(&collector.isOpen, 0)
 	log.Infof("TableGC - finished execution of Close")
 }
@@ -704,4 +711,11 @@ func (collector *TableGC) Status() *Status {
 	}
 
 	return status
+}
+
+func newPool(env tabletenv.Env) *connpool.Pool {
+	return connpool.NewPool(env, "TableGCPool", tabletenv.ConnPoolConfig{
+		Size:        2,
+		IdleTimeout: env.Config().OltpReadPool.IdleTimeout,
+	})
 }

--- a/go/vt/vttablet/tabletserver/gc/tablegc.go
+++ b/go/vt/vttablet/tabletserver/gc/tablegc.go
@@ -143,7 +143,7 @@ func NewTableGC(env tabletenv.Env, ts *topo.Server, lagThrottler *throttle.Throt
 
 		env:  env,
 		ts:   ts,
-		pool: newPool(env),
+		pool: newPool(env, "TableGCPool"),
 
 		purgingTables:    map[string]bool{},
 		checkRequestChan: make(chan bool),
@@ -174,7 +174,8 @@ func (collector *TableGC) Open() (err error) {
 
 	// Reinitialize the pool if it was closed
 	if collector.pool == nil {
-		collector.pool = newPool(collector.env)
+		// Pass empty name so that metrics are not re-registered.
+		collector.pool = newPool(collector.env, "")
 	}
 
 	collector.lifecycleStates, err = schema.ParseGCLifecycle(gcLifecycle)
@@ -713,8 +714,8 @@ func (collector *TableGC) Status() *Status {
 	return status
 }
 
-func newPool(env tabletenv.Env) *connpool.Pool {
-	return connpool.NewPool(env, "TableGCPool", tabletenv.ConnPoolConfig{
+func newPool(env tabletenv.Env, name string) *connpool.Pool {
+	return connpool.NewPool(env, name, tabletenv.ConnPoolConfig{
 		Size:        2,
 		IdleTimeout: env.Config().OltpReadPool.IdleTimeout,
 	})


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
