### PR TITLE
Reproduce UNION coercion bug

### DIFF
--- a/go/test/endtoend/vtgate/queries/union/schema.sql
+++ b/go/test/endtoend/vtgate/queries/union/schema.sql
@@ -13,6 +13,7 @@ create table t1_id2_idx(
 create table t2(
                    id3 bigint,
                    id4 bigint,
+                   e ENUM('a','b','c') DEFAULT 'a',
                    primary key(id3)
 ) Engine=InnoDB;
 

--- a/go/test/endtoend/vtgate/queries/union/union_test.go
+++ b/go/test/endtoend/vtgate/queries/union/union_test.go
@@ -130,6 +130,7 @@ func TestUnion(t *testing.T) {
 	mcmp, closer := start(t)
 	defer closer()
 	mcmp.Exec("insert into t1(id1, id2) values(1, 1), (2, 2)")
+	mcmp.Exec("insert into t2(id3, id4, e) values(1,1,'a'), (2,2,'b'), (3,1,'a'), (4,2,'b')")
 
 	mcmp.AssertMatches(`SELECT 1 UNION SELECT 1 UNION SELECT 1`, `[[INT64(1)]]`)
 	mcmp.AssertMatches(`SELECT 1,'a' UNION SELECT 1,'a' UNION SELECT 1,'a' ORDER BY 1`, `[[INT64(1) VARCHAR("a")]]`)
@@ -140,5 +141,6 @@ func TestUnion(t *testing.T) {
 	mcmp.AssertMatches(`(SELECT 1,'a' order by 1) union (SELECT 1,'a' ORDER BY 1)`, `[[INT64(1) VARCHAR("a")]]`)
 	if utils.BinaryIsAtLeastAtVersion(19, "vtgate") {
 		mcmp.AssertMatches(`(SELECT id2,'a' from t1 where id1 = 1) union (SELECT 'a',id2 from t1 where id1 = 2)`, `[[VARCHAR("1") VARCHAR("a")] [VARCHAR("a") VARCHAR("2")]]`)
+		mcmp.AssertMatches(`(SELECT id3, e from t2 where e = 'a' and id4 = 1) union (SELECT e, id3 from t2 where e='b' and id4 = 2)`, `[[VARCHAR("1") VARCHAR("a")] [VARCHAR("a") VARCHAR("2")]]`)
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description
In `release-19.0-github`, a cross-shard `UNION` query with enum will fail with error `coercion should not try to coerce this value: ENUM("b") (errno 1815) (sqlstate HY000)`
```
go test -v -run 'TestUnion$' ./go/test/endtoend/vtgate/queries/union/...
```

Test:
```sql
CREATE TABLE t2(
  id3 bigint,
  id4 bigint, /* lookup vindex on id4 */
  e ENUM('a','b','c') DEFAULT 'a',
  primary key(id3)
) Engine=InnoDB;
INSERT INTO t2(id3, id4, e) VALUES (1,1,'a'), (2,2,'b'), (3,1,'a'), (4,2,'b');
(SELECT id3, e from t2 where e = 'a' and id4 = 1) union (SELECT e, id3 from t2 where e='b' and id4 = 2);
```


<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
