### PR TITLE
Fail loading an ACL config if the provided file is empty and enforceT…

### DIFF
--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -110,6 +110,10 @@ func (tacl *tableACL) init(configFile string, aclCB func()) error {
 		log.Infof("unable to read tableACL config file: %v  Error: %v", configFile, err)
 		return err
 	}
+	if len(data) == 0 {
+		return errors.New("tableACL config file is empty")
+	}
+
 	config := &tableaclpb.Config{}
 	if err := config.UnmarshalVT(data); err != nil {
 		// try to parse tableacl as json file

--- a/go/vt/tableacl/tableacl_test.go
+++ b/go/vt/tableacl/tableacl_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	"vitess.io/vitess/go/vt/tableacl/acl"
@@ -72,6 +73,19 @@ func TestInitWithValidConfig(t *testing.T) {
 	if err := tacl.init(f.Name(), func() {}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestInitWithEmptyConfig(t *testing.T) {
+	tacl := tableACL{factory: &simpleacl.Factory{}}
+	f, err := os.CreateTemp("", "tableacl")
+	require.NoError(t, err)
+
+	defer os.Remove(f.Name())
+	err = f.Close()
+	require.NoError(t, err)
+
+	err = tacl.init(f.Name(), func() {})
+	require.Error(t, err)
 }
 
 func TestInitFromProto(t *testing.T) {


### PR DESCRIPTION
…ableACLConfig is true (#17274)

This is a backport of https://github.com/vitessio/vitess/pull/17274

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
