### PR TITLE
Set parsed comments in operator for subqueries (#18369)

### DIFF
--- a/go/vt/vtgate/planbuilder/operators/subquery_planning.go
+++ b/go/vt/vtgate/planbuilder/operators/subquery_planning.go
@@ -514,6 +514,9 @@ func tryMergeSubqueryWithOuter(ctx *plancontext.PlanningContext, subQuery *SubQu
 	if !subQuery.IsArgument {
 		op.Source = newFilter(outer.Source, subQuery.Original)
 	}
+	if outer.Comments != nil {
+		op.Comments = outer.Comments
+	}
 	ctx.MergedSubqueries = append(ctx.MergedSubqueries, subQuery.originalSubquery)
 	return op, Rewrote("merged subquery with outer")
 }

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -880,7 +880,6 @@
     "comment": "Comments with subquery",
     "query": "select /* comment */ user.col from user where id IN (select id from user where id > 1 and id < 10)",
     "plan": {
-      "Type": "Scatter",
       "QueryType": "SELECT",
       "Original": "select /* comment */ user.col from user where id IN (select id from user where id > 1 and id < 10)",
       "Instructions": {
@@ -891,7 +890,8 @@
           "Sharded": true
         },
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
-        "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)"
+        "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)",
+	 "Table": "`user`"
       },
       "TablesUsed": [
         "user.user"
@@ -902,7 +902,6 @@
     "comment": "Comments with subquery not merged into a single route",
     "query": "select /* comment */ user.col from user where foo IN (select id from user where id > 1 and id < 10)",
     "plan": {
-      "Type": "Complex",
       "QueryType": "SELECT",
       "Original": "select /* comment */ user.col from user where foo IN (select id from user where id > 1 and id < 10)",
       "Instructions": {
@@ -922,7 +921,8 @@
               "Sharded": true
             },
             "FieldQuery": "select id from `user` where 1 != 1",
-            "Query": "select /* comment */ id from `user` where id > 1 and id < 10"
+            "Query": "select /* comment */ id from `user` where id > 1 and id < 10",
+	     "Table": "`user`"
           },
           {
             "InputName": "Outer",
@@ -933,7 +933,8 @@
               "Sharded": true
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
-            "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1"
+            "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1",
+	     "Table": "`user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -891,7 +891,7 @@
         },
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)",
-		  "Table": "`user`"
+		  	"Table": "`user`"
       },
       "TablesUsed": [
         "user.user"
@@ -922,7 +922,7 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select /* comment */ id from `user` where id > 1 and id < 10",
-			  "Table": "`user`"
+				"Table": "`user`"
           },
           {
             "InputName": "Outer",
@@ -934,7 +934,7 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1",
-			  "Table": "`user`"
+				"Table": "`user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -891,7 +891,7 @@
         },
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)",
-		  	"Table": "`user`"
+        "Table": "`user`"
       },
       "TablesUsed": [
         "user.user"
@@ -922,7 +922,7 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select /* comment */ id from `user` where id > 1 and id < 10",
-				"Table": "`user`"
+            "Table": "`user`"
           },
           {
             "InputName": "Outer",
@@ -934,7 +934,7 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1",
-				"Table": "`user`"
+            "Table": "`user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -891,7 +891,7 @@
         },
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)",
-	 "Table": "`user`"
+	 	"Table": "`user`"
       },
       "TablesUsed": [
         "user.user"
@@ -922,7 +922,7 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select /* comment */ id from `user` where id > 1 and id < 10",
-	     "Table": "`user`"
+	     	"Table": "`user`"
           },
           {
             "InputName": "Outer",
@@ -934,7 +934,7 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1",
-	     "Table": "`user`"
+	     	"Table": "`user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -877,6 +877,74 @@
     }
   },
   {
+    "comment": "Comments with subquery",
+    "query": "select /* comment */ user.col from user where id IN (select id from user where id > 1 and id < 10)",
+    "plan": {
+      "Type": "Scatter",
+      "QueryType": "SELECT",
+      "Original": "select /* comment */ user.col from user where id IN (select id from user where id > 1 and id < 10)",
+      "Instructions": {
+        "OperatorType": "Route",
+        "Variant": "Scatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "FieldQuery": "select `user`.col from `user` where 1 != 1",
+        "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)"
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
+    "comment": "Comments with subquery not merged into a single route",
+    "query": "select /* comment */ user.col from user where foo IN (select id from user where id > 1 and id < 10)",
+    "plan": {
+      "Type": "Complex",
+      "QueryType": "SELECT",
+      "Original": "select /* comment */ user.col from user where foo IN (select id from user where id > 1 and id < 10)",
+      "Instructions": {
+        "OperatorType": "UncorrelatedSubquery",
+        "Variant": "PulloutIn",
+        "PulloutVars": [
+          "__sq_has_values",
+          "__sq1"
+        ],
+        "Inputs": [
+          {
+            "InputName": "SubQuery",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select id from `user` where 1 != 1",
+            "Query": "select /* comment */ id from `user` where id > 1 and id < 10"
+          },
+          {
+            "InputName": "Outer",
+            "OperatorType": "Route",
+            "Variant": "Scatter",
+            "Keyspace": {
+              "Name": "user",
+              "Sharded": true
+            },
+            "FieldQuery": "select `user`.col from `user` where 1 != 1",
+            "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1"
+          }
+        ]
+      },
+      "TablesUsed": [
+        "user.user"
+      ]
+    },
+    "skip_e2e": true
+  },
+  {
     "comment": "for update",
     "query": "select user.col from user join user_extra for update",
     "plan": {

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -891,7 +891,7 @@
         },
         "FieldQuery": "select `user`.col from `user` where 1 != 1",
         "Query": "select /* comment */ `user`.col from `user` where id in (select id from `user` where id > 1 and id < 10)",
-	 	"Table": "`user`"
+		  "Table": "`user`"
       },
       "TablesUsed": [
         "user.user"
@@ -922,7 +922,7 @@
             },
             "FieldQuery": "select id from `user` where 1 != 1",
             "Query": "select /* comment */ id from `user` where id > 1 and id < 10",
-	     	"Table": "`user`"
+			  "Table": "`user`"
           },
           {
             "InputName": "Outer",
@@ -934,7 +934,7 @@
             },
             "FieldQuery": "select `user`.col from `user` where 1 != 1",
             "Query": "select /* comment */ `user`.col from `user` where :__sq_has_values and foo in ::__sq1",
-	     	"Table": "`user`"
+			  "Table": "`user`"
           }
         ]
       },

--- a/go/vt/vtgate/planbuilder/testdata/select_cases.json
+++ b/go/vt/vtgate/planbuilder/testdata/select_cases.json
@@ -896,8 +896,7 @@
       "TablesUsed": [
         "user.user"
       ]
-    },
-    "skip_e2e": true
+    }
   },
   {
     "comment": "Comments with subquery not merged into a single route",
@@ -941,8 +940,7 @@
       "TablesUsed": [
         "user.user"
       ]
-    },
-    "skip_e2e": true
+    }
   },
   {
     "comment": "for update",


### PR DESCRIPTION
This is a backport of https://github.com/vitessio/vitess/pull/18369

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
