### PR TITLE
Allow the use of db credentials when verifying unmanaged tablets conf…

### DIFF
--- a/go/vt/dbconfigs/credentials.go
+++ b/go/vt/dbconfigs/credentials.go
@@ -133,6 +133,12 @@ func GetCredentialsServer() CredentialsServer {
 	return cs
 }
 
+// SetDbCredentialsFilePath sets the value of the `--db-credentials-file` flag.
+// This should be used only for testing.
+func SetDbCredentialsFilePath(path string) {
+	dbCredentialsFile = path
+}
+
 // FileCredentialsServer is a simple implementation of CredentialsServer using
 // a json file. Protected by mu.
 type FileCredentialsServer struct {

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -895,7 +895,12 @@ func (c *TabletConfig) verifyUnmanagedTabletConfig() error {
 		return errors.New("database app user not specified")
 	}
 	if c.DB.App.Password == "" {
-		return errors.New("database app user password not specified")
+		_, pass, err := dbconfigs.GetCredentialsServer().GetUserAndPassword(c.DB.App.User)
+		if err == nil && pass != "" {
+			c.DB.App.Password = pass
+		} else {
+			return errors.New("database app user password not specified")
+		}
 	}
 	// Replication fixes should be disabled for Unmanaged tablets.
 	mysqlctl.DisableActiveReparents = true

--- a/go/vt/vttablet/tabletserver/tabletenv/config_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config_test.go
@@ -484,4 +484,12 @@ func TestVerifyUnmanagedTabletConfig(t *testing.T) {
 	config.DB.App.Password = "testPassword"
 	err = config.verifyUnmanagedTabletConfig()
 	assert.Nil(t, err)
+
+	dbconfigs.SetDbCredentialsFilePath("./data/db_credentials.json")
+	defer dbconfigs.SetDbCredentialsFilePath("")
+	config.DB.App.Password = ""
+
+	err = config.verifyUnmanagedTabletConfig()
+	assert.Nil(t, err)
+	assert.Equal(t, "testPassword", config.DB.App.Password)
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/data/db_credentials.json
+++ b/go/vt/vttablet/tabletserver/tabletenv/data/db_credentials.json
@@ -1,0 +1,3 @@
+{
+  "testUser": ["testPassword"]
+}


### PR DESCRIPTION
…ig (#17984)

This is a backport of https://github.com/vitessio/vitess/pull/17984

<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported
-   [ ] Tests were added or are not required
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
