### PR TITLE
smartconnpool: do not hand connections to expired waiters

### DIFF
--- a/.github/actions/setup-mysql/action.yml
+++ b/.github/actions/setup-mysql/action.yml
@@ -40,8 +40,8 @@ runs:
           sudo DEBIAN_FRONTEND="noninteractive" dpkg -i mysql-apt-config*
           sudo apt-get update
           # libtinfo5 is also needed for older MySQL 5.7 builds.
-          curl -L -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-          sudo dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb
+          curl -L -O http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb
+          sudo dpkg -i libtinfo5_6.3-2ubuntu0.2_amd64.deb
           sudo DEBIAN_FRONTEND="noninteractive" apt-get install -y mysql-client=5.7* mysql-community-server=5.7* mysql-server=5.7* libncurses6
         elif [[ "${{ inputs.flavor }}" == "mysql-8.0" ]]; then
           echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | sudo debconf-set-selections

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -89,4 +89,4 @@ jobs:
         timeout-minutes: 60
         run: |
           source build.env
-          go run test.go -docker=false -skip-build -print-log -follow -retry=1 -timeout=60m vtop_example
+          go run test.go -docker=false -skip-build -print-log -follow -timeout=60m vtop_example

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build:
     name: VTop Example
-    runs-on: ${{ github.repository == 'vitessio/vitess' && 'oracle-vm-8cpu-32gb-x86-64' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'vitessio/vitess' && 'oracle-vm-8cpu-32gb-x86-64' || vars.VTOP_RUNNER || 'ubuntu-latest-xl' }}
 
     steps:
       - name: Skip CI

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -90,3 +90,31 @@ jobs:
         run: |
           source build.env
           go run test.go -docker=false -skip-build -print-log -follow -timeout=60m vtop_example
+
+      - name: Cluster diagnostics on failure
+        if: failure() && steps.changes.outputs.end_to_end == 'true'
+        run: |
+          set +e
+          echo "::group::host capacity"
+          nproc; free -m; df -h /
+          echo "::endgroup::"
+          echo "::group::kubectl get nodes -o wide"
+          kubectl get nodes -o wide
+          echo "::endgroup::"
+          echo "::group::kubectl describe node"
+          kubectl describe node
+          echo "::endgroup::"
+          echo "::group::kubectl get pods -A -o wide"
+          kubectl get pods -A -o wide
+          echo "::endgroup::"
+          echo "::group::kubectl get events -A --sort-by=.lastTimestamp"
+          kubectl get events -A --sort-by=.lastTimestamp
+          echo "::endgroup::"
+          echo "::group::pending pod details"
+          kubectl get pods -A --field-selector=status.phase=Pending -o name | while read -r p; do
+            kubectl describe -n example "${p#pod/}" 2>/dev/null || kubectl describe -A "$p"
+          done
+          echo "::endgroup::"
+          echo "::group::kubectl get pvc,pv -A"
+          kubectl get pvc -A; kubectl get pv
+          echo "::endgroup::"

--- a/.github/workflows/vtop_example.yml
+++ b/.github/workflows/vtop_example.yml
@@ -91,30 +91,14 @@ jobs:
           source build.env
           go run test.go -docker=false -skip-build -print-log -follow -timeout=60m vtop_example
 
-      - name: Cluster diagnostics on failure
+      # Failure-only. Outside vitessio/vitess the runner is selected by
+      # vars.VTOP_RUNNER (see runs-on above); an undersized runner shows up here
+      # as "FailedScheduling ... Insufficient cpu" instead of an opaque timeout.
+      - name: Cluster capacity on failure
         if: failure() && steps.changes.outputs.end_to_end == 'true'
         run: |
           set +e
-          echo "::group::host capacity"
-          nproc; free -m; df -h /
-          echo "::endgroup::"
-          echo "::group::kubectl get nodes -o wide"
-          kubectl get nodes -o wide
-          echo "::endgroup::"
-          echo "::group::kubectl describe node"
-          kubectl describe node
-          echo "::endgroup::"
-          echo "::group::kubectl get pods -A -o wide"
-          kubectl get pods -A -o wide
-          echo "::endgroup::"
-          echo "::group::kubectl get events -A --sort-by=.lastTimestamp"
-          kubectl get events -A --sort-by=.lastTimestamp
-          echo "::endgroup::"
-          echo "::group::pending pod details"
-          kubectl get pods -A --field-selector=status.phase=Pending -o name | while read -r p; do
-            kubectl describe -n example "${p#pod/}" 2>/dev/null || kubectl describe -A "$p"
-          done
-          echo "::endgroup::"
-          echo "::group::kubectl get pvc,pv -A"
-          kubectl get pvc -A; kubectl get pv
-          echo "::endgroup::"
+          echo "host: $(nproc) cpu, $(free -m | awk '/^Mem:/{print $2}') MB"
+          kubectl describe node | sed -n '/^Allocatable:/,/^System Info:/p;/^Allocated resources:/,/^Events:/p'
+          kubectl get pods -A --field-selector=status.phase!=Running
+          kubectl get events -A --field-selector reason=FailedScheduling --sort-by=.lastTimestamp | tail -20

--- a/go/list/list.go
+++ b/go/list/list.go
@@ -144,8 +144,12 @@ func (l *List[T]) Remove(e *Element[T]) {
 
 // RemoveIfPresent removes e from l if e is currently an element of l, and
 // reports whether it was removed. Unlike Remove, it does not panic when e does
-// not belong to l, so callers that may race with another goroutine removing e
-// can use the return value to decide who owns the element.
+// not belong to l; it saves the caller a membership scan, nothing more.
+//
+// It performs no synchronisation of its own. e.list and the link fields touched
+// by remove are ordinary fields, so callers must still serialise every mutation
+// of l externally, as waitlist does with its mutex. Under that lock the return
+// value tells two contenders which of them owns e.
 func (l *List[T]) RemoveIfPresent(e *Element[T]) bool {
 	if e.list != l {
 		return false

--- a/go/list/list.go
+++ b/go/list/list.go
@@ -142,6 +142,18 @@ func (l *List[T]) Remove(e *Element[T]) {
 	l.remove(e)
 }
 
+// RemoveIfPresent removes e from l if e is currently an element of l, and
+// reports whether it was removed. Unlike Remove, it does not panic when e does
+// not belong to l, so callers that may race with another goroutine removing e
+// can use the return value to decide who owns the element.
+func (l *List[T]) RemoveIfPresent(e *Element[T]) bool {
+	if e.list != l {
+		return false
+	}
+	l.remove(e)
+	return true
+}
+
 // PushFront inserts a new element e with value v at the front of list l and returns e.
 func (l *List[T]) PushFront(v T) *Element[T] {
 	return l.insertValue(v, &l.root)

--- a/go/list/list_test.go
+++ b/go/list/list_test.go
@@ -133,3 +133,40 @@ func TestPushFrontValue(t *testing.T) {
 	assert.Equal(t, a, l.Front())
 	assert.Equal(t, a, e.prev)
 }
+
+// TestRemoveIfPresentOwnership pins the contract that smartconnpool's waitlist
+// relies on to decide, between a waiter that is giving up and a returner that is
+// handing out a connection, which of the two owns the element.
+//
+// The return value is the ownership token: exactly one caller may see true for a
+// given element. If RemoveIfPresent ever reported true for an element it did not
+// remove, both parties would notify the same waiter's semaphore, and the extra
+// notification would leak onto whichever waiter next reuses that element from
+// the pool's sync.Pool. No test in smartconnpool asserts this directly.
+func TestRemoveIfPresentOwnership(t *testing.T) {
+	l := New[int]()
+	e := l.PushBack(1)
+
+	// present: removed, and the caller owns it
+	assert.True(t, l.RemoveIfPresent(e))
+	assert.Equal(t, 0, l.Len())
+
+	// already removed: must report false rather than panic or double-remove
+	assert.False(t, l.RemoveIfPresent(e))
+	assert.Equal(t, 0, l.Len())
+
+	// belongs to a different list: must not be removed from either
+	other := New[int]()
+	oe := other.PushBack(2)
+	assert.False(t, l.RemoveIfPresent(oe))
+	assert.Equal(t, 1, other.Len())
+	assert.Equal(t, 0, l.Len())
+
+	// removing one element must leave its neighbours linked
+	l2 := New[int]()
+	a, b, c := l2.PushBack(1), l2.PushBack(2), l2.PushBack(3)
+	assert.True(t, l2.RemoveIfPresent(b))
+	assert.Equal(t, 2, l2.Len())
+	assert.Equal(t, c, a.Next())
+	assert.False(t, l2.RemoveIfPresent(b))
+}

--- a/go/pools/smartconnpool/expired_waiter_invariants_test.go
+++ b/go/pools/smartconnpool/expired_waiter_invariants_test.go
@@ -121,7 +121,7 @@ func TestEvictionPreservesConnectionLifecycle(t *testing.T) {
 	for i, r := range results {
 		if r.expired {
 			require.Falsef(t, r.gotConn,
-				"expired waiter %d received a connection; it can never use it", i)
+				"expired waiter %d received a connection; its acquisition had already expired", i)
 			continue
 		}
 		require.Truef(t, r.gotConn, "live waiter %d was starved of a connection", i)

--- a/go/pools/smartconnpool/expired_waiter_invariants_test.go
+++ b/go/pools/smartconnpool/expired_waiter_invariants_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"vitess.io/vitess/go/list"
+	vtrpcpb "vitess.io/vitess/go/vt/proto/vtrpc"
+	"vitess.io/vitess/go/vt/vterrors"
+)
+
+// TestEvictionPreservesConnectionLifecycle asserts that evicting expired
+// waiters is purely a routing decision: the returned connection is handed to a
+// live waiter untouched, so the pool performs no extra dial, no close, and its
+// active count does not move.
+func TestEvictionPreservesConnectionLifecycle(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	held, err := p.Get(context.Background(), nil)
+	require.NoError(t, err)
+	heldNum := held.Conn.num
+
+	deadline := time.Now().Add(time.Second)
+
+	// Three expired waiters ahead of the single live waiter, so the returner
+	// has to scan past an expired prefix to reach the live target.
+	kinds := []bool{true, true, true, false}
+
+	type outcome struct {
+		expired bool
+		gotConn bool
+		num     int64
+	}
+	results := make([]outcome, len(kinds))
+
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+	for i, isExpired := range kinds {
+		results[i].expired = isExpired
+
+		ctx := context.Context(context.Background())
+		if isExpired {
+			ctx = newLateExpiryCtx(deadline)
+		}
+
+		before := p.wait.waiting()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := p.Get(ctx, nil)
+			if err == nil && conn != nil {
+				mu.Lock()
+				results[i].gotConn = true
+				results[i].num = conn.Conn.num
+				mu.Unlock()
+				p.put(conn)
+			}
+		}()
+
+		require.Eventuallyf(t, func() bool {
+			return p.wait.waiting() == before+1
+		}, 5*time.Second, time.Millisecond, "waiter %d never enqueued", i)
+	}
+
+	time.Sleep(time.Until(deadline) + 100*time.Millisecond)
+
+	// Snapshot the lifecycle counters immediately before the handoff.
+	opensBefore := state.open.Load()
+	closesBefore := state.close.Load()
+	activeBefore := p.Active()
+	capacityBefore := p.Capacity()
+
+	p.put(held)
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("waiters did not finish; connection handoff stalled")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// The connection must have gone to the live waiter and to nobody else.
+	// Without this the lifecycle assertions below would also hold on the
+	// pre-fix code, which satisfies them by handing the connection to an
+	// expired waiter that then returns it.
+	for i, r := range results {
+		if r.expired {
+			require.Falsef(t, r.gotConn,
+				"expired waiter %d received a connection; it can never use it", i)
+			continue
+		}
+		require.Truef(t, r.gotConn, "live waiter %d was starved of a connection", i)
+		assert.Equalf(t, heldNum, r.num,
+			"live waiter %d must receive the very same physical connection that was returned", i)
+	}
+
+	assert.Equal(t, opensBefore, state.open.Load(),
+		"evicting expired waiters must not trigger a new dial")
+	assert.Equal(t, closesBefore, state.close.Load(),
+		"evicting expired waiters must not close the returned connection")
+	assert.Equal(t, activeBefore, p.Active(),
+		"Active must be unchanged: eviction does not create or destroy connections")
+	assert.Equal(t, capacityBefore, p.Capacity(), "Capacity must be unchanged")
+
+	// The connection survived the eviction path and the pool is still usable.
+	reused, err := p.Get(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, heldNum, reused.Conn.num, "the connection must remain reusable")
+	assert.False(t, reused.Conn.IsClosed(), "the connection must not have been closed")
+	p.put(reused)
+}
+
+// TestEvictedWaiterErrorIdentity asserts that a waiter evicted because its
+// context had already expired observes exactly the same error as a waiter that
+// times out on its own, so the client-visible error classification is
+// unchanged by this fix.
+func TestEvictedWaiterErrorIdentity(t *testing.T) {
+	// Control: a waiter that reaches its own deadline with nobody returning a
+	// connection. This is the pre-existing timeout path.
+	t.Run("control_self_timeout", func(t *testing.T) {
+		var state TestState
+		p := NewPool(&Config[*TestConn]{
+			Capacity: 1,
+			LogWait:  state.LogWait,
+		}).Open(newConnector(&state), nil)
+		defer p.Close()
+
+		held, err := p.Get(context.Background(), nil)
+		require.NoError(t, err)
+		defer p.put(held)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		conn, err := p.Get(ctx, nil)
+		require.Nil(t, conn)
+		assertIsPoolTimeout(t, err)
+	})
+
+	// Subject: a waiter whose context expires while parked and which is then
+	// evicted by the returner. It must be indistinguishable from the control.
+	t.Run("evicted_by_returner", func(t *testing.T) {
+		var state TestState
+		p := NewPool(&Config[*TestConn]{
+			Capacity: 1,
+			LogWait:  state.LogWait,
+		}).Open(newConnector(&state), nil)
+		defer p.Close()
+
+		held, err := p.Get(context.Background(), nil)
+		require.NoError(t, err)
+
+		deadline := time.Now().Add(500 * time.Millisecond)
+
+		var (
+			wg      sync.WaitGroup
+			mu      sync.Mutex
+			gotErr  error
+			gotConn *Pooled[*TestConn]
+		)
+		before := p.wait.waiting()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := p.Get(newLateExpiryCtx(deadline), nil)
+			mu.Lock()
+			gotConn, gotErr = conn, err
+			mu.Unlock()
+		}()
+		require.Eventually(t, func() bool {
+			return p.wait.waiting() == before+1
+		}, 5*time.Second, time.Millisecond, "waiter never enqueued")
+
+		time.Sleep(time.Until(deadline) + 100*time.Millisecond)
+		p.put(held)
+		wg.Wait()
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Nil(t, gotConn, "an evicted waiter must not receive a connection")
+		assertIsPoolTimeout(t, gotErr)
+	})
+}
+
+func assertIsPoolTimeout(t *testing.T, err error) {
+	t.Helper()
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTimeout), "want ErrTimeout, got %v", err)
+	assert.Same(t, ErrTimeout, err, "the caller must observe the ErrTimeout sentinel itself")
+	assert.Equal(t, vtrpcpb.Code_RESOURCE_EXHAUSTED, vterrors.Code(err),
+		"the vtrpc classification the client sees must stay RESOURCE_EXHAUSTED")
+}
+
+// pristineTarget reproduces the pre-fix selection rule for a list that
+// contains no expired waiters, and reports the index of the chosen waiter plus
+// the ages the pre-fix code would have left behind.
+//
+//	target = list.Front()
+//	for e := target; e != nil; e = e.Next() {
+//	    if e.age > maxAge || e.setting == connSetting { target = e; break }
+//	    e.age++
+//	}
+func pristineTarget(settings []*Setting, ages []uint32, connSetting *Setting) (int, []uint32) {
+	const maxAge = 8
+
+	finalAges := append([]uint32(nil), ages...)
+	if len(settings) == 0 {
+		return -1, finalAges
+	}
+
+	target := 0
+	for i := range settings {
+		if finalAges[i] > maxAge || settings[i] == connSetting {
+			target = i
+			break
+		}
+		finalAges[i]++
+	}
+	return target, finalAges
+}
+
+// TestLiveWaiterSelectionMatchesPristine proves that when no waiter has an
+// expired context the fix is a behavioural no-op: it selects the same waiter
+// and leaves the same ages behind as the pre-fix code. This is what preserves
+// FIFO ordering, the Setting preference and the anti-starvation ageing.
+func TestLiveWaiterSelectionMatchesPristine(t *testing.T) {
+	s1 := NewSetting("s1", "")
+	s2 := NewSetting("s2", "")
+
+	settingChoices := []*Setting{nil, s1, s2}
+	ageChoices := []uint32{0, 9} // straddles maxAge = 8
+
+	var shapes int
+	for length := 1; length <= 4; length++ {
+		settingIdx := make([]int, length)
+		ageIdx := make([]int, length)
+
+		for {
+			settings := make([]*Setting, length)
+			ages := make([]uint32, length)
+			for i := range settings {
+				settings[i] = settingChoices[settingIdx[i]]
+				ages[i] = ageChoices[ageIdx[i]]
+			}
+
+			for _, connSetting := range settingChoices {
+				shapes++
+				name := fmt.Sprintf("len%d/%v/%v/conn=%v", length, settingIdx, ageIdx, connSetting)
+				gotIdx, gotAges := runLiveSelection(t, settings, ages, connSetting)
+				wantIdx, wantAges := pristineTarget(settings, ages, connSetting)
+
+				require.Equalf(t, wantIdx, gotIdx, "%s: selected a different waiter than the pre-fix rule", name)
+				require.Equalf(t, wantAges, gotAges, "%s: left different ages than the pre-fix rule", name)
+			}
+
+			if !nextOdometer(settingIdx, len(settingChoices), ageIdx, len(ageChoices)) {
+				break
+			}
+		}
+	}
+	t.Logf("verified %d all-live waitlist shapes", shapes)
+}
+
+// runLiveSelection builds a waitlist of live waiters, runs the return path over
+// it once and reports which waiter was handed the connection along with the
+// ages left on the list.
+func runLiveSelection(t *testing.T, settings []*Setting, ages []uint32, connSetting *Setting) (int, []uint32) {
+	t.Helper()
+
+	var wl waitlist[*TestConn]
+	wl.init()
+
+	elems := make([]*list.Element[waiter[*TestConn]], len(settings))
+	for i := range settings {
+		elems[i] = wl.list.PushBack(waiter[*TestConn]{
+			setting: settings[i],
+			ctx:     context.Background(), // live: never expired
+			age:     ages[i],
+		})
+	}
+
+	conn := &Pooled[*TestConn]{Conn: &TestConn{setting: connSetting}}
+	require.True(t, wl.tryReturnConnSlow(conn), "a list of live waiters must always accept the connection")
+
+	selected := -1
+	finalAges := make([]uint32, len(settings))
+	for i, e := range elems {
+		finalAges[i] = e.Value.age
+		if e.Value.conn == conn {
+			require.Equal(t, -1, selected, "at most one waiter may receive the connection")
+			selected = i
+		}
+	}
+	require.NotEqual(t, -1, selected, "some waiter must have received the connection")
+	require.Equal(t, len(settings)-1, wl.waiting(), "exactly one waiter must be removed from the list")
+
+	return selected, finalAges
+}
+
+// nextOdometer advances two parallel digit vectors over their radices and
+// reports whether a new combination was produced.
+func nextOdometer(a []int, radixA int, b []int, radixB int) bool {
+	for i := len(a) - 1; i >= 0; i-- {
+		a[i]++
+		if a[i] < radixA {
+			return true
+		}
+		a[i] = 0
+	}
+	for i := len(b) - 1; i >= 0; i-- {
+		b[i]++
+		if b[i] < radixB {
+			return true
+		}
+		b[i] = 0
+	}
+	return false
+}

--- a/go/pools/smartconnpool/expired_waiter_test.go
+++ b/go/pools/smartconnpool/expired_waiter_test.go
@@ -19,6 +19,7 @@ package smartconnpool
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -139,43 +140,116 @@ func TestExpiredWaitersDoNotReceiveConnections(t *testing.T) {
 	}
 }
 
-// TestExpiredWaiterEvictionIsRaceSafe exercises the eviction path concurrently
-// with waiters removing themselves on genuine context cancellation, to confirm
-// that exactly one party owns each waitlist element.
+// TestExpiredWaiterEvictionIsRaceSafe drives pool-side eviction of expired
+// waiters concurrently with waiters that remove themselves on genuine context
+// cancellation, to confirm that exactly one party owns each waitlist element.
+//
+// Two properties are needed for that race to happen on every run:
+//
+// The pool is held at capacity until every worker is parked. A pool with a free
+// slot satisfies Get immediately, so a serialized or lightly loaded run would
+// enqueue no waiters at all and the drain assertion would pass vacuously.
+//
+// The expiring group uses lateExpiryCtx rather than context.WithTimeout. A real
+// context closes Done on expiry, which wakes its own waiter and makes it remove
+// itself; the pool never evicts it. Only a context that becomes expired without
+// firing Done leaves the element for the pool to evict, which is the path under
+// test.
 func TestExpiredWaiterEvictionIsRaceSafe(t *testing.T) {
+	// Divisible by 3 so each group below has exactly workers/3 members.
+	const workers = 201
+	const capacity = 2
+
 	var state TestState
 
 	p := NewPool(&Config[*TestConn]{
-		Capacity: 2,
+		Capacity: capacity,
 		LogWait:  state.LogWait,
 	}).Open(newConnector(&state), nil)
 	defer p.Close()
 
+	// Occupy every slot, so each worker below is forced onto the waitlist.
+	var held []*Pooled[*TestConn]
+	for i := 0; i < capacity; i++ {
+		conn, err := p.Get(context.Background(), nil)
+		require.NoError(t, err)
+		held = append(held, conn)
+	}
+
+	expiry := time.Now().Add(250 * time.Millisecond)
+	cancelGate := make(chan struct{})
+
+	var evictedServed, liveServed atomic.Int64
+
 	var wg sync.WaitGroup
-	for i := 0; i < 200; i++ {
+	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			var ctx context.Context
-			var cancel context.CancelFunc
+
+			var (
+				ctx    context.Context
+				cancel context.CancelFunc
+				served *atomic.Int64
+			)
 			switch i % 3 {
 			case 0:
-				ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+				// Expires while parked without firing Done, so the pool has to
+				// evict it.
+				ctx, cancel = newLateExpiryCtx(expiry), func() {}
+				served = &evictedServed
 			case 1:
+				// Cancelled while parked, so it removes itself, racing the
+				// eviction scan.
 				ctx, cancel = context.WithCancel(context.Background())
-				go func() { time.Sleep(time.Millisecond); cancel() }()
+				go func() { <-cancelGate; cancel() }()
+				served = nil
 			default:
-				ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+				// Stays live throughout and must be served.
+				ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+				served = &liveServed
 			}
 			defer cancel()
 
 			conn, err := p.Get(ctx, nil)
 			if err == nil && conn != nil {
+				if served != nil {
+					served.Add(1)
+				}
 				p.put(conn)
 			}
 		}(i)
 	}
-	wg.Wait()
 
+	// Nothing can leave the waitlist until cancelGate closes and the held
+	// connections go back, so reaching the full count is a deterministic proof
+	// that the race below is exercised rather than skipped.
+	require.Eventually(t, func() bool {
+		return p.wait.waiting() == workers
+	}, 30*time.Second, time.Millisecond,
+		"workers never all enqueued, so the eviction race was not exercised")
+
+	// Let the lateExpiryCtx group expire while it is parked.
+	time.Sleep(time.Until(expiry) + 50*time.Millisecond)
+
+	// Overlap the two removal paths: closing the gate starts the self-removals,
+	// returning the connections starts the scan that evicts expired waiters.
+	close(cancelGate)
+	for _, conn := range held {
+		p.put(conn)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatalf("workers did not finish; %d still parked", p.wait.waiting())
+	}
+
+	require.Zero(t, evictedServed.Load(),
+		"expired waiter was handed a connection instead of being evicted")
+	require.Equal(t, int64(workers/3), liveServed.Load(),
+		"live waiters were starved by the eviction scan")
 	require.Zero(t, p.wait.waiting(), "waitlist should be drained")
 }

--- a/go/pools/smartconnpool/expired_waiter_test.go
+++ b/go/pools/smartconnpool/expired_waiter_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// lateExpiryCtx is valid at the moment its waiter enqueues and expires while
+// that waiter is parked on the waitlist. Its Done channel is never closed, so
+// the waiter does not remove itself on expiry. This deterministically produces
+// a waitlist containing already-expired waiters, which is the shape that arises
+// in production when clients time out faster than the pool hands out
+// connections.
+type lateExpiryCtx struct {
+	context.Context
+	deadline time.Time
+	done     chan struct{}
+}
+
+func (c *lateExpiryCtx) Deadline() (time.Time, bool) { return c.deadline, true }
+func (c *lateExpiryCtx) Done() <-chan struct{}       { return c.done }
+func (c *lateExpiryCtx) Err() error {
+	if time.Now().After(c.deadline) {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+func newLateExpiryCtx(deadline time.Time) *lateExpiryCtx {
+	return &lateExpiryCtx{
+		Context:  context.Background(),
+		deadline: deadline,
+		done:     make(chan struct{}),
+	}
+}
+
+// TestExpiredWaitersDoNotReceiveConnections asserts that a connection returned
+// to the pool is never handed to a waiter whose context has already expired,
+// including when expired waiters sit *behind* a live waiter in the list.
+//
+// Handing a connection to an expired waiter wastes it: the caller can no longer
+// use it and, in the transaction pool, the failed Begin closes the connection
+// and forces a fresh dial. Under load this starves the live waiters.
+func TestExpiredWaitersDoNotReceiveConnections(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 1,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	// Occupy the only slot so that every subsequent Get parks on the waitlist.
+	held, err := p.Get(context.Background(), nil)
+	require.NoError(t, err)
+
+	// A single shared deadline keeps expiry deterministic across all waiters.
+	deadline := time.Now().Add(2 * time.Second)
+
+	// Expired (true) and live (false) waiters, interleaved so that expired
+	// waiters sit both ahead of and behind live waiters.
+	kinds := []bool{true, true, true, false, true, true, true, false}
+
+	type outcome struct {
+		expired bool
+		gotConn bool
+	}
+	results := make([]outcome, len(kinds))
+
+	var wg sync.WaitGroup
+	for i, isExpired := range kinds {
+		results[i].expired = isExpired
+
+		ctx := context.Context(context.Background())
+		if isExpired {
+			ctx = newLateExpiryCtx(deadline)
+		}
+
+		before := p.wait.waiting()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := p.Get(ctx, nil)
+			if err == nil && conn != nil {
+				results[i].gotConn = true
+				p.put(conn)
+			}
+		}()
+
+		// Wait until this waiter is on the list before starting the next one,
+		// so that the resulting list order is exactly `kinds`.
+		require.Eventuallyf(t, func() bool {
+			return p.wait.waiting() == before+1
+		}, 5*time.Second, time.Millisecond, "waiter %d never enqueued", i)
+	}
+
+	// Let the lateExpiryCtx waiters expire while they are parked.
+	time.Sleep(time.Until(deadline) + 100*time.Millisecond)
+
+	// Releasing the held connection starts the handoff chain.
+	p.put(held)
+
+	waited := make(chan struct{})
+	go func() { wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(30 * time.Second):
+		t.Fatal("waiters did not finish; connection handoff stalled")
+	}
+
+	for i, r := range results {
+		if r.expired {
+			require.Falsef(t, r.gotConn,
+				"expired waiter %d received a connection; it can never use it", i)
+		} else {
+			require.Truef(t, r.gotConn,
+				"live waiter %d was starved of a connection", i)
+		}
+	}
+}
+
+// TestExpiredWaiterEvictionIsRaceSafe exercises the eviction path concurrently
+// with waiters removing themselves on genuine context cancellation, to confirm
+// that exactly one party owns each waitlist element.
+func TestExpiredWaiterEvictionIsRaceSafe(t *testing.T) {
+	var state TestState
+
+	p := NewPool(&Config[*TestConn]{
+		Capacity: 2,
+		LogWait:  state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			var ctx context.Context
+			var cancel context.CancelFunc
+			switch i % 3 {
+			case 0:
+				ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
+			case 1:
+				ctx, cancel = context.WithCancel(context.Background())
+				go func() { time.Sleep(time.Millisecond); cancel() }()
+			default:
+				ctx, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+			}
+			defer cancel()
+
+			conn, err := p.Get(ctx, nil)
+			if err == nil && conn != nil {
+				p.put(conn)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	require.Zero(t, p.wait.waiting(), "waitlist should be drained")
+}

--- a/go/pools/smartconnpool/expired_waiter_test.go
+++ b/go/pools/smartconnpool/expired_waiter_test.go
@@ -61,9 +61,9 @@ func newLateExpiryCtx(deadline time.Time) *lateExpiryCtx {
 // to the pool is never handed to a waiter whose context has already expired,
 // including when expired waiters sit *behind* a live waiter in the list.
 //
-// Handing a connection to an expired waiter wastes the handoff: the caller can
-// no longer use it, so the return makes no progress for anyone and the live
-// waiters keep waiting.
+// Serving an expired waiter wastes the handoff: its acquisition has already
+// expired, so it is no longer eligible for a successful acquisition, and the
+// return makes no progress for the live waiters that are still waiting.
 func TestExpiredWaitersDoNotReceiveConnections(t *testing.T) {
 	var state TestState
 
@@ -134,7 +134,7 @@ func TestExpiredWaitersDoNotReceiveConnections(t *testing.T) {
 	for i, r := range results {
 		if r.expired {
 			require.Falsef(t, r.gotConn,
-				"expired waiter %d received a connection; it can never use it", i)
+				"expired waiter %d received a connection; its acquisition had already expired", i)
 		} else {
 			require.Truef(t, r.gotConn,
 				"live waiter %d was starved of a connection", i)

--- a/go/pools/smartconnpool/expired_waiter_test.go
+++ b/go/pools/smartconnpool/expired_waiter_test.go
@@ -29,9 +29,11 @@ import (
 // lateExpiryCtx is valid at the moment its waiter enqueues and expires while
 // that waiter is parked on the waitlist. Its Done channel is never closed, so
 // the waiter does not remove itself on expiry. This deterministically produces
-// a waitlist containing already-expired waiters, which is the shape that arises
-// in production when clients time out faster than the pool hands out
-// connections.
+// a waitlist containing already-expired waiters.
+//
+// Scope: this pins the precondition -- an expired waiter still linked when a
+// returner examines it -- so that selection behaviour can be asserted without a
+// race. It is not evidence about how often real workloads reach that state.
 type lateExpiryCtx struct {
 	context.Context
 	deadline time.Time
@@ -59,9 +61,9 @@ func newLateExpiryCtx(deadline time.Time) *lateExpiryCtx {
 // to the pool is never handed to a waiter whose context has already expired,
 // including when expired waiters sit *behind* a live waiter in the list.
 //
-// Handing a connection to an expired waiter wastes it: the caller can no longer
-// use it and, in the transaction pool, the failed Begin closes the connection
-// and forces a fresh dial. Under load this starves the live waiters.
+// Handing a connection to an expired waiter wastes the handoff: the caller can
+// no longer use it, so the return makes no progress for anyone and the live
+// waiters keep waiting.
 func TestExpiredWaitersDoNotReceiveConnections(t *testing.T) {
 	var state TestState
 

--- a/go/pools/smartconnpool/pool.go
+++ b/go/pools/smartconnpool/pool.go
@@ -613,7 +613,7 @@ func (pool *ConnPool[C]) get(ctx context.Context) (*Pooled[C], error) {
 		}
 
 		conn, err = pool.wait.waitForConn(ctx, nil, *closeChan)
-		if err != nil {
+		if err != nil || conn == nil {
 			return nil, ErrTimeout
 		}
 		pool.recordWait(start)
@@ -676,7 +676,7 @@ func (pool *ConnPool[C]) getWithSetting(ctx context.Context, setting *Setting) (
 		}
 
 		conn, err = pool.wait.waitForConn(ctx, setting, *closeChan)
-		if err != nil {
+		if err != nil || conn == nil {
 			return nil, ErrTimeout
 		}
 		pool.recordWait(start)

--- a/go/pools/smartconnpool/post_deadline_handoff_test.go
+++ b/go/pools/smartconnpool/post_deadline_handoff_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2025 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smartconnpool
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// expiredCtx becomes expired (Err() != nil) once its deadline passes, but its
+// Done() channel never fires.
+//
+// This deterministically pins the exact state that tryReturnConnSlow observes in
+// production: a waiter whose acquisition deadline has already passed but which is
+// still linked in the waitlist because its own goroutine has not yet executed, or
+// has not yet won, its self-removal under wl.mu.
+//
+// Using a real context.WithTimeout would reach the same state only by winning a
+// race against the returner. Suppressing Done() removes the race without changing
+// anything the returner can observe: tryReturnConnSlow only ever reads
+// waiter.ctx, never waiter's Done channel.
+type expiredCtx struct{ deadline time.Time }
+
+func (c *expiredCtx) Deadline() (time.Time, bool) { return c.deadline, true }
+func (c *expiredCtx) Done() <-chan struct{}       { return nil }
+func (c *expiredCtx) Value(any) any               { return nil }
+func (c *expiredCtx) Err() error {
+	if time.Now().After(c.deadline) {
+		return context.DeadlineExceeded
+	}
+	return nil
+}
+
+// TestPostDeadlineHandoff asserts the invariant that upstream vitessio/vitess
+// #20308 restores: the pool must never hand a connection to a waiter whose
+// acquisition context has already expired.
+//
+// On pristine v21 this test FAILS, reproducing the production signature:
+//   - Get() returns success after its acquisition deadline
+//   - the success-only WaitTime/WaitCount metric therefore exceeds the deadline
+//   - and no connection is closed or re-dialled while it happens
+func TestPostDeadlineHandoff(t *testing.T) {
+	// scaled equivalent of the production --queryserver-config-txpool-timeout=1s
+	const acquireTimeout = 100 * time.Millisecond
+
+	var state TestState
+	p := NewPool(&Config[*TestConn]{
+		Capacity:    1,
+		IdleTimeout: time.Minute,
+		LogWait:     state.LogWait,
+	}).Open(newConnector(&state), nil)
+	defer p.Close()
+
+	// Occupy the only connection so the next caller must enqueue as a waiter.
+	held, err := p.Get(context.Background(), nil)
+	require.NoError(t, err)
+	dialsAfterWarmup := state.open.Load()
+
+	type result struct {
+		conn    *Pooled[*TestConn]
+		err     error
+		elapsed time.Duration
+		ctxErr  error
+	}
+	resc := make(chan result, 1)
+
+	ctx := &expiredCtx{deadline: time.Now().Add(acquireTimeout)}
+	go func() {
+		start := time.Now()
+		c, err := p.Get(ctx, nil)
+		resc <- result{conn: c, err: err, elapsed: time.Since(start), ctxErr: ctx.Err()}
+	}()
+
+	// Wait until the caller is actually parked on the waitlist.
+	deadline := time.Now().Add(5 * time.Second)
+	for p.wait.waiting() == 0 {
+		require.True(t, time.Now().Before(deadline), "waiter never enqueued")
+		time.Sleep(time.Millisecond)
+	}
+
+	// Let the acquisition deadline pass while the waiter is parked.
+	time.Sleep(2 * acquireTimeout)
+	require.Error(t, ctx.Err(), "precondition: waiter ctx must be expired before the return")
+	require.Equal(t, 1, p.wait.waiting(), "precondition: expired waiter is still on the waitlist")
+
+	// The returner hands the connection back. Front of the list is the expired waiter.
+	waitsBefore := p.Metrics.WaitCount()
+	held.Recycle()
+
+	r := <-resc
+
+	t.Logf("Get -> err=%v elapsed=%v ctxErr=%v | WaitCount=%d WaitTime=%v | dials=%d closes=%d",
+		r.err, r.elapsed, r.ctxErr,
+		p.Metrics.WaitCount(), p.Metrics.WaitTime(),
+		state.open.Load(), state.close.Load())
+
+	// (1) The pool must not report success to a waiter that had already expired.
+	if r.err == nil && r.conn != nil {
+		mean := time.Duration(0)
+		if n := p.Metrics.WaitCount(); n > 0 {
+			mean = time.Duration(int64(p.Metrics.WaitTime()) / n)
+		}
+		r.conn.Recycle()
+		t.Fatalf("POST-DEADLINE HANDOFF: pool delivered a connection to a waiter whose "+
+			"acquisition context expired %v earlier.\n"+
+			"  Get() returned SUCCESS after %v (acquisition deadline %v)\n"+
+			"  success-only metric mean wait = %v  > deadline %v  <-- production signature\n"+
+			"  dials during handoff = %d (no redial)  closes = %d",
+			r.elapsed-acquireTimeout, r.elapsed, acquireTimeout,
+			mean, acquireTimeout,
+			state.open.Load()-dialsAfterWarmup, state.close.Load())
+	}
+
+	// (2) With the fix, the expired waiter is evicted and the acquisition fails.
+	require.Error(t, r.err, "expired waiter must not receive a connection")
+	require.Nil(t, r.conn)
+
+	// (3) Evicting the expired waiter must NOT pollute the success-only wait
+	// metric. WaitCount/WaitTime have always counted successful acquisitions
+	// only; a failed eviction must leave them untouched.
+	require.Equal(t, waitsBefore, p.Metrics.WaitCount(),
+		"evicted expired waiter must not increment WaitCount (success-only metric)")
+
+	// (3) Either way, no connection is closed or re-dialled by this path. This is
+	// why the mechanism is invisible in MySQL's Connections counter.
+	require.Equal(t, dialsAfterWarmup, state.open.Load(), "no redial must occur")
+	require.Zero(t, state.close.Load(), "no connection close must occur")
+}
+
+// TestInteriorExpiredWaiterNotServed covers the case that a prefix-only
+// eviction would miss. Production deadlines are heterogeneous, so an expired
+// waiter can sit BEHIND a live one. tryReturnConnSlow picks its target by
+// `age > maxAge || setting == connSetting`, so an interior expired waiter whose
+// Setting matches the returned connection can be selected ahead of the live
+// waiter at the front of the list.
+//
+// Upstream #20308 scans the whole list rather than stopping at the first live
+// waiter. This test asserts that behaviour: the interior expired waiter must be
+// evicted, and the live waiter must receive the connection.
+func TestInteriorExpiredWaiterNotServed(t *testing.T) {
+	settingA := NewSetting("set workload='olap'", "set workload='oltp'")
+
+	state := &TestState{}
+	p := NewPool(&Config[*TestConn]{Capacity: 1, IdleTimeout: time.Hour}).
+		Open(newConnector(state), nil)
+	defer p.Close()
+
+	// Hold the only connection and stamp settingA on it, so the connection that
+	// is later returned carries settingA.
+	held, err := p.Get(context.Background(), settingA)
+	require.NoError(t, err)
+
+	var liveServed, expiredServed atomic.Int64
+	var wg sync.WaitGroup
+
+	// (1) LIVE waiter, no Setting -> occupies the FRONT of the waitlist.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if c, err := p.Get(ctx, nil); err == nil && c != nil {
+			liveServed.Add(1)
+			c.Recycle()
+		}
+	}()
+	for p.wait.waiting() < 1 {
+		time.Sleep(200 * time.Microsecond)
+	}
+
+	// (2) EXPIRED waiter, Setting == settingA -> sits BEHIND the live waiter,
+	// and is the better `setting == connSetting` match for the returned conn.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ctx := &expiredCtx{deadline: time.Now().Add(50 * time.Millisecond)}
+		if c, err := p.Get(ctx, settingA); err == nil && c != nil {
+			expiredServed.Add(1)
+			c.Recycle()
+		}
+	}()
+	for p.wait.waiting() < 2 {
+		time.Sleep(200 * time.Microsecond)
+	}
+	time.Sleep(100 * time.Millisecond) // waiter 2 is now expired, still linked
+
+	held.Recycle()
+	wg.Wait()
+
+	t.Logf("live served=%d  expired served=%d", liveServed.Load(), expiredServed.Load())
+	require.Zero(t, expiredServed.Load(),
+		"interior expired waiter must not receive a connection")
+	require.Equal(t, int64(1), liveServed.Load(),
+		"live waiter must receive the connection instead")
+}

--- a/go/pools/smartconnpool/post_deadline_handoff_test.go
+++ b/go/pools/smartconnpool/post_deadline_handoff_test.go
@@ -29,15 +29,20 @@ import (
 // expiredCtx becomes expired (Err() != nil) once its deadline passes, but its
 // Done() channel never fires.
 //
-// This deterministically pins the exact state that tryReturnConnSlow observes in
-// production: a waiter whose acquisition deadline has already passed but which is
-// still linked in the waitlist because its own goroutine has not yet executed, or
-// has not yet won, its self-removal under wl.mu.
+// This deterministically pins the pool-side state under test: a waiter whose
+// acquisition deadline has already passed but which is still linked in the
+// waitlist, because its own goroutine has not yet executed, or has not yet won,
+// its self-removal under wl.mu.
 //
 // Using a real context.WithTimeout would reach the same state only by winning a
 // race against the returner. Suppressing Done() removes the race without changing
 // anything the returner can observe: tryReturnConnSlow only ever reads
-// waiter.ctx, never waiter's Done channel.
+// waiter.ctx, never the waiter's Done channel.
+//
+// Scope: this proves what the pool does IF an expired waiter is still linked
+// when a returner examines it. It says nothing about how often real workloads
+// reach that state; TestExpiredWaiterEvictionIsRaceSafe exercises the same
+// invariant with real contexts and the real race.
 type expiredCtx struct{ deadline time.Time }
 
 func (c *expiredCtx) Deadline() (time.Time, bool) { return c.deadline, true }
@@ -54,7 +59,8 @@ func (c *expiredCtx) Err() error {
 // #20308 restores: the pool must never hand a connection to a waiter whose
 // acquisition context has already expired.
 //
-// On pristine v21 this test FAILS, reproducing the production signature:
+// Against the unfixed base this test FAILS, showing the observable shape of the
+// defect:
 //   - Get() returns success after its acquisition deadline
 //   - the success-only WaitTime/WaitCount metric therefore exceeds the deadline
 //   - and no connection is closed or re-dialled while it happens
@@ -123,7 +129,7 @@ func TestPostDeadlineHandoff(t *testing.T) {
 		t.Fatalf("POST-DEADLINE HANDOFF: pool delivered a connection to a waiter whose "+
 			"acquisition context expired %v earlier.\n"+
 			"  Get() returned SUCCESS after %v (acquisition deadline %v)\n"+
-			"  success-only metric mean wait = %v  > deadline %v  <-- production signature\n"+
+			"  success-only metric mean wait = %v  > deadline %v  <-- the defect\n"+
 			"  dials during handoff = %d (no redial)  closes = %d",
 			r.elapsed-acquireTimeout, r.elapsed, acquireTimeout,
 			mean, acquireTimeout,
@@ -140,8 +146,9 @@ func TestPostDeadlineHandoff(t *testing.T) {
 	require.Equal(t, waitsBefore, p.Metrics.WaitCount(),
 		"evicted expired waiter must not increment WaitCount (success-only metric)")
 
-	// (3) Either way, no connection is closed or re-dialled by this path. This is
-	// why the mechanism is invisible in MySQL's Connections counter.
+	// (4) Either way, no connection is closed or re-dialled by this path. The
+	// defect wastes a handoff; it does not churn connections, which is why it
+	// leaves no trace in MySQL's Connections counter.
 	require.Equal(t, dialsAfterWarmup, state.open.Load(), "no redial must occur")
 	require.Zero(t, state.close.Load(), "no connection close must occur")
 }
@@ -153,9 +160,12 @@ func TestPostDeadlineHandoff(t *testing.T) {
 // Setting matches the returned connection can be selected ahead of the live
 // waiter at the front of the list.
 //
-// Upstream #20308 scans the whole list rather than stopping at the first live
-// waiter. This test asserts that behaviour: the interior expired waiter must be
-// evicted, and the live waiter must receive the connection.
+// The selection loop does not stop at the first live waiter: it records that
+// waiter as a fallback target and keeps going until it finds a better match
+// (`age > maxAge || setting == connSetting`) or reaches the end. Every waiter it
+// examines on the way is checked for expiry. This test asserts that behaviour:
+// the interior expired waiter must be evicted, and the live waiter must receive
+// the connection.
 func TestInteriorExpiredWaiterNotServed(t *testing.T) {
 	settingA := NewSetting("set workload='olap'", "set workload='oltp'")
 

--- a/go/pools/smartconnpool/post_deadline_handoff_test.go
+++ b/go/pools/smartconnpool/post_deadline_handoff_test.go
@@ -183,9 +183,9 @@ func TestInteriorExpiredWaiterNotServed(t *testing.T) {
 			c.Recycle()
 		}
 	}()
-	for p.wait.waiting() < 1 {
-		time.Sleep(200 * time.Microsecond)
-	}
+	require.Eventually(t, func() bool {
+		return p.wait.waiting() >= 1
+	}, 30*time.Second, 200*time.Microsecond, "live waiter never enqueued")
 
 	// (2) EXPIRED waiter, Setting == settingA -> sits BEHIND the live waiter,
 	// and is the better `setting == connSetting` match for the returned conn.
@@ -198,9 +198,9 @@ func TestInteriorExpiredWaiterNotServed(t *testing.T) {
 			c.Recycle()
 		}
 	}()
-	for p.wait.waiting() < 2 {
-		time.Sleep(200 * time.Microsecond)
-	}
+	require.Eventually(t, func() bool {
+		return p.wait.waiting() >= 2
+	}, 30*time.Second, 200*time.Microsecond, "expired waiter never enqueued")
 	time.Sleep(100 * time.Millisecond) // waiter 2 is now expired, still linked
 
 	held.Recycle()

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -70,17 +70,10 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 	select {
 	case <-closeChan:
 		// Pool was closed while we were waiting.
-		removed := false
-
+		// Try to remove ourselves from the list. If we lose the race against
+		// tryReturnConnSlow, it owns the element and will notify our semaphore.
 		wl.mu.Lock()
-		// Try to find and remove ourselves from the list.
-		for e := wl.list.Front(); e != nil; e = e.Next() {
-			if e == elem {
-				wl.list.Remove(elem)
-				removed = true
-				break
-			}
-		}
+		removed := wl.list.RemoveIfPresent(elem)
 		wl.mu.Unlock()
 
 		// If we removed ourselves from the waitlist, we need to notify our semaphore
@@ -100,17 +93,10 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 	case <-ctx.Done():
 		// Context expired. We need to try to remove ourselves from the waitlist to
 		// prevent another goroutine from trying to hand us a connection later on.
-		removed := false
-
+		// If we lose the race against tryReturnConnSlow, it owns the element and
+		// will notify our semaphore.
 		wl.mu.Lock()
-		// Try to find and remove ourselves from the list.
-		for e := wl.list.Front(); e != nil; e = e.Next() {
-			if e == elem {
-				wl.list.Remove(elem)
-				removed = true
-				break
-			}
-		}
+		removed := wl.list.RemoveIfPresent(elem)
 		wl.mu.Unlock()
 
 		// If we removed ourselves from the waitlist, we need to notify our semaphore
@@ -140,9 +126,13 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 
-	// iterate the waitlist looking for waiters with an expired Context,
-	// or remove everything if force is true
+	// iterate the waitlist looking for waiters that are still live and have not
+	// been skipped over yet. Waiters whose context has already expired are not
+	// counted: opening a new connection on their behalf would be wasted work.
 	for e := wl.list.Front(); e != nil; e = e.Next() {
+		if e.Value.ctx != nil && e.Value.ctx.Err() != nil {
+			continue
+		}
 		if e.Value.age == 0 {
 			maybeStarving++
 		}
@@ -165,15 +155,33 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	const maxAge = 8
 	var (
 		target      *list.Element[waiter[D]]
+		expired     []*list.Element[waiter[D]]
 		connSetting = conn.Conn.Setting()
 	)
 
 	wl.mu.Lock()
-	target = wl.list.Front()
-	// iterate through the waitlist looking for either waiters that have been
-	// here too long, or a waiter that is looking exactly for the same Setting
-	// as the one we have in our connection.
-	for e := target; e != nil; e = e.Next() {
+	var next *list.Element[waiter[D]]
+	for e := wl.list.Front(); e != nil; e = next {
+		// capture the successor before a possible Remove unlinks e
+		next = e.Next()
+
+		// Never hand a connection over to a waiter whose context has already
+		// expired: that waiter can no longer use it, and for the transaction
+		// pool the subsequent failed Begin closes the connection and forces a
+		// fresh dial. Evict the expired waiter instead so the connection stays
+		// available for a waiter that can still use it. Expired waiters can sit
+		// anywhere in the list, not just at the front, because deadlines are
+		// heterogeneous, so the whole scan has to check.
+		if e.Value.ctx != nil && e.Value.ctx.Err() != nil {
+			wl.list.Remove(e)
+			expired = append(expired, e)
+			continue
+		}
+
+		if target == nil {
+			// front-most live waiter, used unless a better match is found below
+			target = e
+		}
 		if e.Value.age > maxAge || e.Value.setting == connSetting {
 			target = e
 			break
@@ -189,6 +197,15 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		wl.list.Remove(target)
 	}
 	wl.mu.Unlock()
+
+	// Wake the evicted waiters. Their conn stays nil, which waitForConn hands
+	// back to the caller and which Get maps to a timeout. This is safe to do
+	// after releasing the lock: an evicted waiter is blocked on its semaphore
+	// and cannot return (nor recycle its list element) until we notify it, and
+	// because we removed it from the list under the lock nobody else can.
+	for _, e := range expired {
+		e.Value.sema.notify(false)
+	}
 
 	// maybe there isn't anybody to hand over the connection to, because we've
 	// raced with another client returning another connection

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -136,8 +136,9 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 	defer wl.mu.Unlock()
 
 	// count the waiters that no returner has aged yet; they may be starving.
-	// Waiters whose context has already expired cannot use a connection and are
-	// only listed until a returner evicts them, so they don't count.
+	// Waiters whose acquisition context has already expired are no longer
+	// eligible for a successful acquisition and are only listed until a
+	// returner evicts them, so they don't count.
 	for e := wl.list.Front(); e != nil; e = e.Next() {
 		if e.Value.ctx.Err() != nil {
 			continue
@@ -179,9 +180,11 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		// capture the successor before a possible Remove unlinks e
 		next = e.Next()
 
-		// Never hand a connection to a waiter whose context has already
-		// expired: that waiter cannot use it, so the handoff would consume a
-		// return without making progress for anyone. Evicting it instead also
+		// Never hand a connection to a waiter whose acquisition context has
+		// already expired: it is no longer eligible to receive a successful
+		// acquisition, so serving it would violate the acquisition deadline
+		// and consume a return that a live waiter is still waiting for.
+		// Evicting it instead also
 		// stops the list accumulating a dead prefix that every later return
 		// has to walk. Deadlines are heterogeneous, so expired waiters sit
 		// anywhere in the list, not only at the front; every waiter examined

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -93,6 +93,15 @@ func (wl *waitlist[C]) waitForConn(ctx context.Context, setting *Setting, closeC
 	case <-ctx.Done():
 		// Context expired. We need to try to remove ourselves from the waitlist to
 		// prevent another goroutine from trying to hand us a connection later on.
+		//
+		// This removal MUST stay O(1). The code this replaces scanned the list
+		// to locate elem before removing it, which is O(n) while holding wl.mu,
+		// the mutex that serializes every acquisition and return in the pool.
+		// Every waiter that times out pays that cost, so a timeout storm at
+		// depth n serializes O(n^2) work on the hot path. RemoveIfPresent is a
+		// required part of this backport, not incidental cleanup: do not
+		// reintroduce the scan.
+		//
 		// If we lose the race against tryReturnConnSlow, it owns the element and
 		// will notify our semaphore.
 		wl.mu.Lock()
@@ -126,11 +135,11 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 	wl.mu.Lock()
 	defer wl.mu.Unlock()
 
-	// iterate the waitlist looking for waiters that are still live and have not
-	// been skipped over yet. Waiters whose context has already expired are not
-	// counted: opening a new connection on their behalf would be wasted work.
+	// count the waiters that no returner has aged yet; they may be starving.
+	// Waiters whose context has already expired cannot use a connection and are
+	// only listed until a returner evicts them, so they don't count.
 	for e := wl.list.Front(); e != nil; e = e.Next() {
-		if e.Value.ctx != nil && e.Value.ctx.Err() != nil {
+		if e.Value.ctx.Err() != nil {
 			continue
 		}
 		if e.Value.age == 0 {
@@ -142,6 +151,11 @@ func (wl *waitlist[C]) maybeStarvingCount() (maybeStarving int) {
 }
 
 // tryReturnConn tries handing over a connection to one of the waiters in the pool.
+//
+// Waiters whose context has already expired when they are examined are evicted
+// rather than selected. A waiter that is still live when examined but expires
+// before it is notified will still receive the connection; that narrow race is
+// unchanged by this fix and is not something the pool can close from here.
 func (wl *waitlist[D]) tryReturnConn(conn *Pooled[D]) bool {
 	// fast path: if there's nobody waiting there's nothing to do
 	if wl.list.Len() == 0 {
@@ -165,14 +179,14 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		// capture the successor before a possible Remove unlinks e
 		next = e.Next()
 
-		// Never hand a connection over to a waiter whose context has already
-		// expired: that waiter can no longer use it, and for the transaction
-		// pool the subsequent failed Begin closes the connection and forces a
-		// fresh dial. Evict the expired waiter instead so the connection stays
-		// available for a waiter that can still use it. Expired waiters can sit
-		// anywhere in the list, not just at the front, because deadlines are
-		// heterogeneous, so the whole scan has to check.
-		if e.Value.ctx != nil && e.Value.ctx.Err() != nil {
+		// Never hand a connection to a waiter whose context has already
+		// expired: that waiter cannot use it, so the handoff would consume a
+		// return without making progress for anyone. Evicting it instead also
+		// stops the list accumulating a dead prefix that every later return
+		// has to walk. Deadlines are heterogeneous, so expired waiters sit
+		// anywhere in the list, not only at the front; every waiter examined
+		// before a target is selected is therefore checked for expiry.
+		if e.Value.ctx.Err() != nil {
 			wl.list.Remove(e)
 			expired = append(expired, e)
 			continue
@@ -199,10 +213,15 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	wl.mu.Unlock()
 
 	// Wake the evicted waiters. Their conn stays nil, which waitForConn hands
-	// back to the caller and which Get maps to a timeout. This is safe to do
-	// after releasing the lock: an evicted waiter is blocked on its semaphore
-	// and cannot return (nor recycle its list element) until we notify it, and
-	// because we removed it from the list under the lock nobody else can.
+	// back to the caller and which Get maps to a timeout.
+	//
+	// This is deliberately outside the lock. It is safe because an evicted
+	// waiter is blocked on its semaphore and cannot return (nor recycle its
+	// list element) until we notify it, and because we removed it from the list
+	// under the lock nobody else can. Keeping the wakeups out of the critical
+	// section matters: under mass expiry this loop can be long, and wl.mu
+	// serializes every acquisition and return in the pool. `expired` is nil,
+	// and allocates nothing, whenever no waiter has expired.
 	for _, e := range expired {
 		e.Value.sema.notify(false)
 	}

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -184,11 +184,11 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		// already expired: it is no longer eligible to receive a successful
 		// acquisition, so serving it would violate the acquisition deadline
 		// and consume a return that a live waiter is still waiting for.
-		// Evicting it instead also
-		// stops the list accumulating a dead prefix that every later return
-		// has to walk. Deadlines are heterogeneous, so expired waiters sit
-		// anywhere in the list, not only at the front; every waiter examined
-		// before a target is selected is therefore checked for expiry.
+		// Evicting it instead also stops the list accumulating a dead prefix
+		// that every later return has to walk. Deadlines are heterogeneous, so
+		// expired waiters sit anywhere in the list, not only at the front;
+		// every waiter examined before a target is selected is therefore
+		// checked for expiry.
 		if e.Value.ctx.Err() != nil {
 			wl.list.Remove(e)
 			expired = append(expired, e)

--- a/go/pools/smartconnpool/waitlist.go
+++ b/go/pools/smartconnpool/waitlist.go
@@ -212,6 +212,19 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 	}
 	wl.mu.Unlock()
 
+	// Hand the connection over before waking the evicted waiters. The target is
+	// the only party here with a deadline left to make; the evicted waiters are
+	// all going to return a timeout, so their wakeups must not queue in front of
+	// the handoff. Under mass expiry that ordering is the difference between the
+	// target being notified immediately and being notified after N semaphore
+	// releases, which would widen the window in which it expires post-selection.
+	if target != nil {
+		// write the connection into the waiter and signal their semaphore. they'll
+		// wake up to pick up the connection.
+		target.Value.conn = conn
+		target.Value.sema.notify(true)
+	}
+
 	// Wake the evicted waiters. Their conn stays nil, which waitForConn hands
 	// back to the caller and which Get maps to a timeout.
 	//
@@ -226,18 +239,9 @@ func (wl *waitlist[D]) tryReturnConnSlow(conn *Pooled[D]) bool {
 		e.Value.sema.notify(false)
 	}
 
-	// maybe there isn't anybody to hand over the connection to, because we've
-	// raced with another client returning another connection
-	if target == nil {
-		return false
-	}
-
-	// if we have a target to return the connection to, simply write the connection
-	// into the waiter and signal their semaphore. they'll wake up to pick up the
-	// connection.
-	target.Value.conn = conn
-	target.Value.sema.notify(true)
-	return true
+	// target is nil when there was nobody to hand the connection to, because
+	// every waiter had expired or we raced with another returner.
+	return target != nil
 }
 
 func (wl *waitlist[C]) init() {

--- a/tools/get_previous_release.sh
+++ b/tools/get_previous_release.sh
@@ -22,12 +22,12 @@
 
 target_release=""
 
-base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*.0$')
+base_release_branch=$(echo "$1" | grep -E 'release-[0-9]*\.0(-github)?$')
 if [ "$base_release_branch" == "" ]; then
-  base_release_branch=$(echo "$2" | grep -E 'release-[0-9]*.0$')
+  base_release_branch=$(echo "$2" | grep -E 'release-[0-9]*\.0(-github)?$')
 fi
 if [ "$base_release_branch" != "" ]; then
-  major_release=$(echo "$base_release_branch" | sed 's/release-*//' | sed 's/\.0//')
+  major_release=$(echo "$base_release_branch" | sed 's#.*release-##' | sed 's/\.0.*//')
   target_major_release=$((major_release-1))
   target_release="release-$target_major_release.0"
 else


### PR DESCRIPTION
## Problem

`smartconnpool` can hand a returned connection to a waiter whose connection-acquisition context has **already expired**. That waiter is no longer eligible to receive a successful acquisition, so serving it violates the acquisition deadline and consumes a return that a live waiter is still waiting for.

**`release-22.0-github` is affected.** `go/pools/smartconnpool/waitlist.go` is the *same blob* (`40c924da32`) on `release-21.0-github`, `release-22.0-github` and upstream `release-22.0`. Upstream fixed this in v23 and v24 only; there is no upstream v22 backport.

The defect reproduces deterministically on this branch's exact base (`3a64a919f9`):

```
--- FAIL: TestPostDeadlineHandoff
    POST-DEADLINE HANDOFF: pool delivered a connection to a waiter whose
    acquisition context expired 101.201708ms earlier.
```

## Two must-preserve invariants

Both ship together. A future forward-port or backport must keep **both**.

### Invariant A — a waiter already expired when examined is not selected

> A waiter already expired when examined for selection must not be selected.

`tryReturnConnSlow` checks `e.Value.ctx.Err()` on every waiter it examines before it settles on a target, and removes the expired ones instead of leaving them eligible. Deadlines are heterogeneous, so expired waiters sit anywhere in the list, not only at the front.

Serving an already-expired waiter wastes the handoff: its acquisition has already expired, so the return makes no progress for anyone and the live waiters keep waiting.

**Scope of that claim.** This is a *selection-time* invariant. It does **not** claim that "no connection can ever be delivered to a context that is expired by the time the waiter wakes." A waiter that is live when selected can still have its context expire before it resumes. That post-selection expiry is inherent to any concurrent handoff, is indistinguishable from a caller cancelling a microsecond after acquisition, and is **unchanged by this PR**. The defect fixed here is narrower and unambiguous: the pool consulted a waiter it could already see was expired, and handed it the connection anyway.

### Invariant B — waiter self-removal is O(1)

> A waiter removing itself from the waitlist must not scan the waitlist while holding `wl.mu`.

This is **not** cleanup that rode along with Invariant A. It is load-bearing.

| | before | after |
|---|---|---|
| work removed | up to `n` pointer-chasing iterations per waiter cancellation | one `e.list` identity check plus an unlink |
| serialized resource | `wl.mu`, the single mutex serializing **every** acquisition and return in the pool | same mutex, held for O(1) |
| complexity | `O(n)` per cancellation, so `O(n²)` across a timeout storm at depth `n` | `O(1)` per cancellation, `O(n)` across the storm |
| expected observable effect | mutex hold time on the cancellation path grows with waitlist depth | hold time independent of waitlist depth |

The code being replaced walked the list to locate `elem` before removing it, on **both** `waitForConn` exit paths. This is a source-level complexity claim, not a measured production one.

### Why both ship

They are independent properties of the same code path. Invariant A changes *which* waiter is selected but does nothing about the cost every timing-out waiter pays under `wl.mu`. Invariant B bounds that cost but would still let the pool hand connections to waiters whose acquisitions have already expired. The upstream change contains both.

An out-of-tree overload harness — not part of this PR, and **not** production-equivalent — made the dependency concrete: under sufficient offered load the unfixed pool collapsed; **A alone was worse than unfixed**; **B alone** restored goodput; A+B restored goodput. Take that as a reason not to drop B, not as evidence about production behaviour.

> A future backporter must not conclude that "the `ctx` check is the real fix and `RemoveIfPresent` is cleanup."

## Reviewer focus

The production change is 3 files, **+98 / −39** — of which only **33 added / 25 removed lines are code**, the rest being comments and blank lines. Four things deserve scrutiny; the rest of the diff is tests, comments and CI.

1. **The `tryReturnConnSlow` loop** (`waitlist.go`) — `next` is captured before `Remove` unlinks `e`; the front-most live waiter is retained as the fallback target; the `break` conditions are unchanged from pristine. `TestLiveWaiterSelectionMatchesPristine` passes on the unfixed base *and* here, which is what makes it evidence that live-waiter selection is untouched.
2. **Eviction notification happens outside `wl.mu`, and *after* the handoff** — deliberate, and the one place this PR diverges structurally from upstream v23, which notifies inline under the lock. Rationale for staying outside the lock: under mass expiry that loop is long, and `wl.mu` serializes the whole pool, so notifying inline would work against Invariant B. Rationale for ordering: the target is the only party with a deadline left to make, so its handoff must not queue behind `N` semaphore releases — an earlier revision of this PR had that backwards and was caught in adversarial review. Safety: both elements are unlinked under the lock and parked on their semaphores, so no other party can observe or recycle them before we notify.
3. **The `RemoveIfPresent` ownership protocol** — the returned boolean *is* the ownership token. Exactly one of {timing-out waiter, returner} sees `true`, and exactly one `notify` happens per waiter. Both production callers hold `wl.mu`; the helper does no synchronisation of its own.
4. **`maybeStarvingCount` skipping expired waiters** — this changes connection-opening decisions, so it is worth a look. It is identical to upstream v23.

## Why this is a semantic port and not a cherry-pick

Between v22 and v23, upstream **rewrote the waiter notification mechanism**, so the upstream patch does not apply here:

| | v21 / **v22 (this branch)** | v23 / v24 (upstream fix) |
|---|---|---|
| waiter wakeup | `semaphore` + helper goroutine + `done` chan | `conn chan *Pooled[C]` (buffered, cap 1) |
| `waiter.ctx` | **already present** | added by #20308 |
| eviction signal | `sema.notify(false)`, `conn` stays `nil` | `conn <- nil` |
| nil→error mapping | `conn == nil` guard in `pool.go` | `waitResult()` helper |
| `wait` field | value | pointer (alignment, because the struct grew) |

Cherry-picking `459f4cfe21` conflicts in every hunk of `waitlist.go` and drags in the `wait *waitlist[C]` pointer + `stack.go` alignment commentary, which exist only because upstream's waiter struct *grew* — ours already has `ctx`, so it does not grow. Those hunks are deliberately **not** ported.

What *is* portable applies exactly: `go/list/list.go` is byte-identical between v22 and the upstream fix's parent, so `RemoveIfPresent` is taken verbatim.

### Port scope: what is and is not identical between v21 and v22

The **waitlist and list implementations relevant to the defect are byte-identical** between the validated v21 base and v22, which is why the fix transplants without adaptation:

| file | `release-21.0-github` (`865f789e15`) | `release-22.0-github` (`3a64a919f9`) | |
|---|---|---|---|
| `go/pools/smartconnpool/waitlist.go` | `40c924da32` | `40c924da32` | identical |
| `go/list/list.go` | `2ad837b7c6` | `2ad837b7c6` | identical |
| `go/pools/smartconnpool/pool.go` | `4eb6c4fa57` | `cca706bc1c` | **differs** |

**`pool.go` is not byte-identical**, and the difference is substantive rather than cosmetic: v22 adds idle-count handling — `MaxIdleCount`, `idleCount`, `setIdleCount()`, `IdleCount()` and `closeOnIdleLimitReached`.

That interaction was reviewed separately, because this fix touches its reachability. In `tryReturnConn`:

```go
if pool.wait.tryReturnConn(conn) {
    return true
}
if pool.closeOnIdleLimitReached(conn) {   // v22-only
    return false
}
```

Before this change, an expired waiter would absorb the connection and `wait.tryReturnConn` would report `true`. After it, when every waiter is expired and **no live waiter remains**, the eviction path falls through and returns `false` — so `closeOnIdleLimitReached` becomes reachable in a case where it previously was not.

This is inert under GitHub's deployed/default configuration. `defaultConfig.TxPool` (`go/vt/vttablet/tabletserver/tabletenv/config.go`) sets only `Size`, `Timeout` and `IdleTimeout`, so `MaxIdleCount` takes the zero value, and `setIdleCount()` maps `maxIdleCount == 0` to the pool **capacity**. The guard `idle <= pool.idleCount.Load()` therefore always holds on the first iteration and `closeOnIdleLimitReached` returns `false` without closing anything. When an operator does set `--queryserver-config-txpool-max-idle-count`, closing a genuinely idle connection when no live waiter wants it is the intended v22 behaviour, not a regression introduced here.

## Fix

- `tryReturnConnSlow` evicts expired waiters as it examines them, so an **interior** expired waiter is removed rather than selected (the loop still stops at the existing `age > maxAge || setting == connSetting` condition)
- the front-most **live** waiter is the fallback target
- `maybeStarvingCount` no longer counts expired waiters as starving
- `go/list` gains O(1) `RemoveIfPresent`, replacing the O(n) scan a cancelling waiter performed under `wl.mu` (**Invariant B**), and giving the waiter and the returner an unambiguous ownership token
- `WaitCount`/`WaitTime` are restored to **successful-acquisition-only** semantics: `waitForConn` can now return `(nil, nil)`, so `recordWait` is guarded on `conn == nil` (see the operator note below)

### Operator note: metric semantics after this fix

After this fix, **evicted/expired waiters no longer increment `WaitCount`/`WaitTime`.** This restores those metrics to successful-acquisition semantics: `pool.go` returns `ErrTimeout` on the `conn == nil` guard *before* reaching `pool.recordWait(start)`.

> **A decrease in `WaitCount`/`WaitTime` after rollout must not automatically be interpreted as reduced contention.** Part of any observed drop is the removal of expired-waiter handoffs that were previously being recorded as successful acquisitions. Offered load and contention may be unchanged; the denominator changed. Compare against `ResourceExhausted`/timeout rates and pool `InUse` before concluding anything about contention.

### Accepted residual

With a live target, the handoff now happens before the eviction wakeups. In the **all-expired** case (`target == nil`) the connection is not stacked until `tryReturnConnSlow` returns, so the `O(N)` wakeup loop is charged synchronously to the returning goroutine (`Pooled.Recycle` → `put` → `tryReturnConn`), and a waiter enqueuing in that window waits it out.

Accepted, not fixed: it needs an extreme transient population of linked-but-expired waiters, the delay is proportional to work that must happen anyway, and the 100 ms starvation worker is a backstop. Upstream v23 is **strictly worse** here — it performs the same `N` wakeups while still holding `wl.mu`, blocking the whole pool rather than one returner.


## Rollout contract

Deliberately small. This changes waiter selection and `WaitCount`/`WaitTime` semantics, and nothing else.

**Canary success — all of:**

| signal | expectation |
|---|---|
| transaction goodput | flat or better vs. a control tablet |
| `ResourceExhausted` / txpool acquisition timeouts | no regression |
| TxPool liveness | no Active-high / InUse-single-digit divergence |
| connection lifecycle (`Connections`, dial rate) | flat — this path neither closes nor dials |
| CPU, goroutine count, RSS | no material regression |
| acquisition wait metrics | read **only** with the changed semantics below |

**Roll back if any of:**

- transaction goodput drops on the canary tablet and not on control
- `ResourceExhausted` rises on the canary tablet and not on control
- TxPool `InUse` collapses while `Active` stays high — i.e. the liveness shape this change is meant to make *less* likely, appearing *after* rollout
- connection open/close rate rises materially — this change has no lifecycle path, so that would indicate an unmodelled interaction
- any panic, deadlock or stuck waiter in `smartconnpool`

**Not a success signal:** a drop in `WaitCount`/`WaitTime`. Part of any drop is definitional, because evicted waiters no longer record a wait. See the operator note above.

#239 adds waiter-level telemetry that would make the InUse/Active and waiter-population signals easier to read. It is **not a dependency** for this PR; if it lands first, treat it as additional evidence.


## Validation

Every test below was run against **pristine `3a64a919f9`** (this PR's exact merge-base) and against this branch. Six are regression tests that **fail on the unfixed base for the intended reason**; one is a deliberate control that must pass on *both*.

| Test | unfixed base | this PR | what it catches that nothing else does |
|---|---|---|---|
| `TestPostDeadlineHandoff` | ❌ fail | ✅ pass | `Get()` returning **success** after its acquisition deadline, and the success-only wait metric therefore exceeding that deadline |
| `TestExpiredWaitersDoNotReceiveConnections` | ❌ fail | ✅ pass | an expired waiter being served when it sits in the **prefix** of the list |
| `TestInteriorExpiredWaiterNotServed` | ❌ fail | ✅ pass | an expired waiter **behind a live one** being selected because its `Setting` matches the returned connection — the case a prefix-only eviction would miss |
| `TestExpiredWaiterEvictionIsRaceSafe` | ❌ fail | ✅ pass | the same invariant under **real `context.WithTimeout`** and the real returner/waiter race, rather than a pinned synthetic context |
| `TestEvictionPreservesConnectionLifecycle` | ❌ fail | ✅ pass | eviction silently becoming a *lifecycle* event: asserts the live waiter gets **the same physical connection**, with no extra dial, no close, and `Active`/`Capacity` unchanged |
| `TestEvictedWaiterErrorIdentity` | ❌ fail | ✅ pass | an evicted waiter observing a **different error** than a self-timing-out one; asserts the `ErrTimeout` sentinel itself and `RESOURCE_EXHAUSTED` |
| `TestLiveWaiterSelectionMatchesPristine` | ✅ pass *(control)* | ✅ pass | a regression in **live-waiter selection**. It passes on the unfixed base by design — that is what makes it evidence that FIFO, `Setting` preference and ageing are untouched |
| `go/list` `TestRemoveIfPresentOwnership` | n/a *(helper is new)* | ✅ pass | the **ownership token** contract. Proven non-vacuous by mutation: making `RemoveIfPresent` always return `true` fails it. Nothing in `smartconnpool` asserts this directly, and breaking it would double-notify a waiter |

Failure on the base is for the right reason, not merely a red result — e.g.:

```
--- FAIL: TestExpiredWaiterEvictionIsRaceSafe
    expired_waiter_test.go:252: Should be zero, but was 67
    Messages: expired waiter was handed a connection instead of being evicted
```

**Ordering preserved.** `TestLiveWaiterSelectionMatchesPristine` checks **4662 all-live waitlist shapes** (lengths 1–4 × settings {nil,s1,s2} × ages {0,9} straddling `maxAge=8`) and asserts the fix picks the *same waiter* and leaves the *same ages* as the pre-fix rule. When no waiter is expired, this change is a behavioural no-op.

**Behavioural equivalence with upstream.** The four black-box tests in `expired_waiter_test.go` and `post_deadline_handoff_test.go` compile and run **unmodified** against upstream `release-23.0` at `459f4cfe21` (which contains #20308) and all pass. `expired_waiter_invariants_test.go` is white-box and cannot compile there by construction — it reads `waiter.conn`, which is a `*Pooled[C]` field in v22 and a channel in v23. The goal is equivalence on the defect invariant, not source-level similarity.

**Scope of the synthetic contexts.** `expiredCtx` and `lateExpiryCtx` report `Err() != nil` without firing `Done()`. That pins the precondition — an expired waiter still linked when a returner examines it — so selection can be asserted deterministically instead of by winning a race. It proves what the pool does **if** that state is reached; it is **not** evidence about how often production reaches it. `TestExpiredWaiterEvictionIsRaceSafe` covers the same invariant with real contexts and the real race.

Suites: `go/pools/...` and `go/list/...` pass, under `-race` (×3) and under `-race -cpu=1`. `go vet` and `gofmt` clean.

## Not included

- no waiter cap (the flag does not exist in this lineage; removed upstream in v20 by #15323)
- no txpool timeout tuning
- no Launch admission control
- no unrelated post-v22 fixes

## CI changes on this branch (not part of the fix)

The smartconnpool fix is the 6 files above. The 6 CI commits touch no Go code at all — `git show --name-only <ci-commit> -- go/` is empty for each of them, so the CI work cannot affect the fix.

The branch also carries **6 CI-infrastructure commits touching 3 files and no Go code**. All of them repair defects that were already failing this repository before this PR; none is conceptually part of the backport. They are here only because #241 cannot produce a valid CI signal without them.

| commit | file | what it repairs | why it was needed here |
|---|---|---|---|
| `514addf408` | `.github/actions/setup-mysql/action.yml` | `libtinfo5` 6.3-2ubuntu0.1 → 0.2 | the pinned `.deb` now **404s** — Ubuntu dropped the superseded build from the pool, so `Unit Test (mysql57)` and `(evalengine_mysql57)` died at *Setup MySQL* |
| `531f93e259` | `.github/workflows/vtop_example.yml` | drop `-retry=1` | upstream removed the `-retry` flag in #19182; fork merge `234e15a386` resurrected the argument, so `VTop Example` aborted after **11 s** with `flag provided but not defined: -retry`. Removing it restores byte-identical parity with upstream v22 |
| `712f7055bb` | `tools/get_previous_release.sh` | match `release-NN.0-github` | the regex `release-[0-9]*.0$` misses `-github` suffixes, so the upgrade/downgrade jobs resolved "previous release" to **release-23.0** instead of release-21.0 and failed on the v22→v23 `schema_change_signal`→`schema-change-signal` rename |
| `43df8a8dfa` | `.github/workflows/vtop_example.yml` | runner selection | see sizing below |
| `22362a104f`, `550af21363` | `.github/workflows/vtop_example.yml` | failure-only capacity dump | guardrail for the runner knob; 11 lines, `if: failure()` |

`VTop Example` had **never** passed in this repository — it is `failure` on every non-cancelled run on `release-22.0`, `release-23.0` and `backport-18369-v22`. It now passes in **8m43s**.

### VTop runner sizing — measured, and deliberately not overclaimed

`runs-on` is now:

```yaml
runs-on: ${{ github.repository == 'vitessio/vitess' && 'oracle-vm-8cpu-32gb-x86-64' || vars.VTOP_RUNNER || 'ubuntu-latest-xl' }}
```

All three branches were verified by executing the expression in CI: upstream still resolves to `oracle-vm-8cpu-32gb-x86-64`; with a repository variable set the override wins; with it unset the fallback is `ubuntu-latest-xl`. **Upstream behaviour is unchanged.**

What the workload actually needs, sampled every 10 s across a full green run:

| quantity | measured |
|---|---|
| peak scheduled **CPU requests** | **4130 m** |
| peak scheduled memory requests | 9890 Mi |
| peak pod count | 32 |
| default `ubuntu-24.04` allocatable | **4000 m** / 15.6 GiB |

The default runner misses by **130 millicores (3.3 %)**. That is the entire failure: the kind node reached `3930m (98 %)` allocated and two `vtbackup-init` pods could not be placed — `0/1 nodes are available: 1 Insufficient cpu`. Memory was never a constraint (55 %).

So, stated precisely:

* **actual workload requirement ≈ 4.2 CPU** — any runner with ~5–6 CPU would schedule it;
* **16 CPU is *not* intrinsically required.** `ubuntu-latest-xl` is simply the smallest label that both *schedules in this organisation* and *has enough CPU*.

Eight runner labels were tested. Only `ubuntu-24.04`/`ubuntu-latest` (4 CPU) and the `-xl` tier (16 CPU / 64 GB, both `ubuntu-latest-xl` and `ubuntu-22.04-xl`) ever schedule here; `oracle-vm-8cpu-32gb-x86-64`, `gh-hosted-runners-16cores-1-24.04`, `ubuntu-latest-{4,8}-cores`, `ubuntu-latest-8-core`, `ubuntu-latest-l` and `ubuntu-latest-m` stayed queued indefinitely and were cancelled. There is no intermediate tier to pick — the jump is 4 → 16.

**Cost.** Per PR, VTop went from 4 CPU × ~34 min = ~138 CPU-min *and a guaranteed red result*, to 16 CPU × ~11 min = ~176 CPU-min for a green one: **≈1.28× the CPU-minutes for a signal that previously did not exist**. If a ~6–8 CPU label is ever exposed to this org, set the repository/organisation variable **`VTOP_RUNNER`** to it and the cost drops with **no source change**. That hook is the intended cost-control mechanism.

**Extraction.** All 3 CI files are repo-wide fixes that every PR in this fork benefits from. They should be lifted into a single follow-up CI PR against `release-22.0-github` after this merges; #241 can then drop them. They are retained here only because without them this PR has no trustworthy CI signal — not because they belong to the backport.

## Relationship to #238

#238 is the same fix targeting `release-21.0-github`. `waitlist.go` and `go/list/list.go` are byte-identical between the two branches — the *fixed* `waitlist.go` blob is `6850a54632` on both — so the defect-relevant production code is the validated v21 artifact unchanged. `pool.go` is **not** byte-identical between v21 and v22 (see [Port scope](#port-scope-what-is-and-is-not-identical-between-v21-and-v22) above); the hunk this PR applies to it is textually the same, but it lands on a different surrounding file. #238 could not be retargeted: its branch is rooted in v21, so repointing the base at `release-22.0-github` renders as **222 commits / 740 files / +20,234 −7,607** instead of the 6-file smartconnpool change here.

## Incident context

Production evidence from incident 5229 is on #238. The confidence statement is unchanged:

> The production signature is strongly consistent with this defect and the behavior is reproducible on the deployed commit, but waiter-level telemetry was unavailable to prove incident causality conclusively.

## Upstream

vitessio/vitess#20308, backported upstream as #20354 (v23) and #20355 (v24).








